### PR TITLE
API changes for readability, consistency, less clutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ apps/minlog/bin/
 apps/pfinder/pfinder
 docs/html
 
+
+OffBrand/.DS_Store
+
+*.xcuserstate
+
+*.xcsettings

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ OffBrand/.DS_Store
 *.xcuserstate
 
 *.xcsettings
+
+*.xcbkptlist

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ OffBrand/.DS_Store
 *.xcsettings
 
 *.xcbkptlist
+
+.DS_Store

--- a/OffBrand/OffBrand.xcodeproj/project.pbxproj
+++ b/OffBrand/OffBrand.xcodeproj/project.pbxproj
@@ -14,9 +14,7 @@
 		BC3693A4176D34D700EBE188 /* Term_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369351176D34D700EBE188 /* Term_Private.h */; };
 		BC3693A5176D34D700EBE188 /* RTable.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369352176D34D700EBE188 /* RTable.h */; };
 		BC3693A6176D34D700EBE188 /* Term.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369353176D34D700EBE188 /* Term.h */; };
-		BC3693A7176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369354176D34D700EBE188 /* Makefile */; };
 		BC3693A8176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369357176D34D700EBE188 /* Makefile */; };
-		BC3693B1176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369367176D34D700EBE188 /* Makefile */; };
 		BC3693B2176D34D700EBE188 /* OBDeque.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369374176D34D700EBE188 /* OBDeque.h */; };
 		BC3693B3176D34D700EBE188 /* OBInt.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369375176D34D700EBE188 /* OBInt.h */; };
 		BC3693B4176D34D700EBE188 /* OBMap.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369376176D34D700EBE188 /* OBMap.h */; };
@@ -31,7 +29,6 @@
 		BC3693BD176D34D700EBE188 /* OBString_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369380176D34D700EBE188 /* OBString_Private.h */; };
 		BC3693BE176D34D700EBE188 /* OBTest_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369381176D34D700EBE188 /* OBTest_Private.h */; };
 		BC3693BF176D34D700EBE188 /* OBVector_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369382176D34D700EBE188 /* OBVector_Private.h */; };
-		BC3693C0176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369384176D34D700EBE188 /* Makefile */; };
 		BC3693C1176D34D700EBE188 /* PrivateHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36938C176D34D700EBE188 /* PrivateHeader.h */; };
 		BC3693C2176D34D700EBE188 /* PublicHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36938D176D34D700EBE188 /* PublicHeader.h */; };
 		BC3693C5176D34D700EBE188 /* OBDeque.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369392176D34D700EBE188 /* OBDeque.c */; };
@@ -119,6 +116,10 @@
 		BC36939D176D34D700EBE188 /* OBString_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBString_test.c; sourceTree = "<group>"; };
 		BC36939E176D34D700EBE188 /* OBTest_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBTest_test.c; sourceTree = "<group>"; };
 		BC36939F176D34D700EBE188 /* OBVector_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBVector_test.c; sourceTree = "<group>"; };
+		BC7978E9176E12290073143E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		BC7978EC176E12290073143E /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		BC7978ED176E12290073143E /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		BC7978EE176E12290073143E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +144,7 @@
 				BC369385176D34D700EBE188 /* README.txt */,
 				BC369386176D34D700EBE188 /* scripts */,
 				BC369390176D34D700EBE188 /* src */,
+				BC7978E6176E12290073143E /* Frameworks */,
 				BC369343176D34AA00EBE188 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -372,6 +374,25 @@
 			path = tests;
 			sourceTree = "<group>";
 		};
+		BC7978E6176E12290073143E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BC7978E9176E12290073143E /* Cocoa.framework */,
+				BC7978EB176E12290073143E /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		BC7978EB176E12290073143E /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BC7978EC176E12290073143E /* AppKit.framework */,
+				BC7978ED176E12290073143E /* CoreData.framework */,
+				BC7978EE176E12290073143E /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -456,10 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC3693A7176D34D700EBE188 /* Makefile in Sources */,
 				BC3693A8176D34D700EBE188 /* Makefile in Sources */,
-				BC3693B1176D34D700EBE188 /* Makefile in Sources */,
-				BC3693C0176D34D700EBE188 /* Makefile in Sources */,
 				BC3693C5176D34D700EBE188 /* OBDeque.c in Sources */,
 				BC3693C6176D34D700EBE188 /* OBInt.c in Sources */,
 				BC3693C7176D34D700EBE188 /* OBMap.c in Sources */,
@@ -573,6 +591,7 @@
 				BC369348176D34AA00EBE188 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/OffBrand/OffBrand.xcodeproj/project.pbxproj
+++ b/OffBrand/OffBrand.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		BC3693A4176D34D700EBE188 /* Term_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369351176D34D700EBE188 /* Term_Private.h */; };
 		BC3693A5176D34D700EBE188 /* RTable.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369352176D34D700EBE188 /* RTable.h */; };
 		BC3693A6176D34D700EBE188 /* Term.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369353176D34D700EBE188 /* Term.h */; };
-		BC3693A8176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369357176D34D700EBE188 /* Makefile */; };
 		BC3693B2176D34D700EBE188 /* OBDeque.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369374176D34D700EBE188 /* OBDeque.h */; };
 		BC3693B3176D34D700EBE188 /* OBInt.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369375176D34D700EBE188 /* OBInt.h */; };
 		BC3693B4176D34D700EBE188 /* OBMap.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369376176D34D700EBE188 /* OBMap.h */; };
@@ -477,7 +476,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC3693A8176D34D700EBE188 /* Makefile in Sources */,
 				BC3693C5176D34D700EBE188 /* OBDeque.c in Sources */,
 				BC3693C6176D34D700EBE188 /* OBInt.c in Sources */,
 				BC3693C7176D34D700EBE188 /* OBMap.c in Sources */,

--- a/OffBrand/OffBrand.xcodeproj/project.pbxproj
+++ b/OffBrand/OffBrand.xcodeproj/project.pbxproj
@@ -43,7 +43,53 @@
 		BC3693CF176D34D700EBE188 /* OBString_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939D176D34D700EBE188 /* OBString_test.c */; };
 		BC3693D0176D34D700EBE188 /* OBTest_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939E176D34D700EBE188 /* OBTest_test.c */; };
 		BC3693D1176D34D700EBE188 /* OBVector_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939F176D34D700EBE188 /* OBVector_test.c */; };
+		BCEDDA22177024CF00040AE4 /* NCube.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36935C176D34D700EBE188 /* NCube.c */; };
+		BCEDDA23177024CF00040AE4 /* RTable.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36935D176D34D700EBE188 /* RTable.c */; };
+		BCEDDA24177024CF00040AE4 /* Term.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36935E176D34D700EBE188 /* Term.c */; };
+		BCEDDA25177024CF00040AE4 /* minlog_funct.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369360176D34D700EBE188 /* minlog_funct.c */; };
+		BCEDDA2C1770297200040AE4 /* libOffBrand.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC369342176D34AA00EBE188 /* libOffBrand.a */; };
+		BCEDDA2E17702B8E00040AE4 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369361176D34D700EBE188 /* main.c */; };
+		BCEDDA3C17702C1C00040AE4 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369366176D34D700EBE188 /* main.c */; };
+		BCEDDA3F17702CE100040AE4 /* libOffBrand.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC369342176D34AA00EBE188 /* libOffBrand.a */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BCEDDA291770293000040AE4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC36933A176D34AA00EBE188 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC369341176D34AA00EBE188;
+			remoteInfo = OffBrand;
+		};
+		BCEDDA3D17702CDD00040AE4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC36933A176D34AA00EBE188 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC369341176D34AA00EBE188;
+			remoteInfo = OffBrand;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		BCEDDA17177024B200040AE4 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		BCEDDA3117702BBF00040AE4 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		BC369342176D34AA00EBE188 /* libOffBrand.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOffBrand.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,6 +165,8 @@
 		BC7978EC176E12290073143E /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		BC7978ED176E12290073143E /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		BC7978EE176E12290073143E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		BCEDDA19177024B200040AE4 /* minlog */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = minlog; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCEDDA3317702BBF00040AE4 /* pfinder */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = pfinder; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +174,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCEDDA16177024B200040AE4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCEDDA2C1770297200040AE4 /* libOffBrand.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCEDDA3017702BBF00040AE4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCEDDA3F17702CE100040AE4 /* libOffBrand.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,6 +216,8 @@
 			isa = PBXGroup;
 			children = (
 				BC369342176D34AA00EBE188 /* libOffBrand.a */,
+				BCEDDA19177024B200040AE4 /* minlog */,
+				BCEDDA3317702BBF00040AE4 /* pfinder */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -445,6 +511,42 @@
 			productReference = BC369342176D34AA00EBE188 /* libOffBrand.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		BCEDDA18177024B200040AE4 /* minlog */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCEDDA1F177024B200040AE4 /* Build configuration list for PBXNativeTarget "minlog" */;
+			buildPhases = (
+				BCEDDA15177024B200040AE4 /* Sources */,
+				BCEDDA16177024B200040AE4 /* Frameworks */,
+				BCEDDA17177024B200040AE4 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BCEDDA2A1770293000040AE4 /* PBXTargetDependency */,
+			);
+			name = minlog;
+			productName = minlog;
+			productReference = BCEDDA19177024B200040AE4 /* minlog */;
+			productType = "com.apple.product-type.tool";
+		};
+		BCEDDA3217702BBF00040AE4 /* pfinder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCEDDA3917702BBF00040AE4 /* Build configuration list for PBXNativeTarget "pfinder" */;
+			buildPhases = (
+				BCEDDA2F17702BBF00040AE4 /* Sources */,
+				BCEDDA3017702BBF00040AE4 /* Frameworks */,
+				BCEDDA3117702BBF00040AE4 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BCEDDA3E17702CDD00040AE4 /* PBXTargetDependency */,
+			);
+			name = pfinder;
+			productName = pfinder;
+			productReference = BCEDDA3317702BBF00040AE4 /* pfinder */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -467,6 +569,8 @@
 			projectRoot = "";
 			targets = (
 				BC369341176D34AA00EBE188 /* OffBrand */,
+				BCEDDA18177024B200040AE4 /* minlog */,
+				BCEDDA3217702BBF00040AE4 /* pfinder */,
 			);
 		};
 /* End PBXProject section */
@@ -492,7 +596,40 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BCEDDA15177024B200040AE4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCEDDA22177024CF00040AE4 /* NCube.c in Sources */,
+				BCEDDA23177024CF00040AE4 /* RTable.c in Sources */,
+				BCEDDA24177024CF00040AE4 /* Term.c in Sources */,
+				BCEDDA25177024CF00040AE4 /* minlog_funct.c in Sources */,
+				BCEDDA2E17702B8E00040AE4 /* main.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCEDDA2F17702BBF00040AE4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCEDDA3C17702C1C00040AE4 /* main.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BCEDDA2A1770293000040AE4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC369341176D34AA00EBE188 /* OffBrand */;
+			targetProxy = BCEDDA291770293000040AE4 /* PBXContainerItemProxy */;
+		};
+		BCEDDA3E17702CDD00040AE4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC369341176D34AA00EBE188 /* OffBrand */;
+			targetProxy = BCEDDA3D17702CDD00040AE4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		BC369344176D34AA00EBE188 /* Debug */ = {
@@ -570,6 +707,38 @@
 			};
 			name = Release;
 		};
+		BCEDDA20177024B200040AE4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		BCEDDA21177024B200040AE4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		BCEDDA3A17702BBF00040AE4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		BCEDDA3B17702BBF00040AE4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -590,6 +759,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		BCEDDA1F177024B200040AE4 /* Build configuration list for PBXNativeTarget "minlog" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCEDDA20177024B200040AE4 /* Debug */,
+				BCEDDA21177024B200040AE4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		BCEDDA3917702BBF00040AE4 /* Build configuration list for PBXNativeTarget "pfinder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCEDDA3A17702BBF00040AE4 /* Debug */,
+				BCEDDA3B17702BBF00040AE4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/OffBrand/OffBrand.xcodeproj/project.pbxproj
+++ b/OffBrand/OffBrand.xcodeproj/project.pbxproj
@@ -1,0 +1,580 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BC3693A0176D34D700EBE188 /* minlog_funct.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36934C176D34D700EBE188 /* minlog_funct.h */; };
+		BC3693A1176D34D700EBE188 /* NCube.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36934D176D34D700EBE188 /* NCube.h */; };
+		BC3693A2176D34D700EBE188 /* NCube_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36934F176D34D700EBE188 /* NCube_Private.h */; };
+		BC3693A3176D34D700EBE188 /* RTable_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369350176D34D700EBE188 /* RTable_Private.h */; };
+		BC3693A4176D34D700EBE188 /* Term_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369351176D34D700EBE188 /* Term_Private.h */; };
+		BC3693A5176D34D700EBE188 /* RTable.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369352176D34D700EBE188 /* RTable.h */; };
+		BC3693A6176D34D700EBE188 /* Term.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369353176D34D700EBE188 /* Term.h */; };
+		BC3693A7176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369354176D34D700EBE188 /* Makefile */; };
+		BC3693A8176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369357176D34D700EBE188 /* Makefile */; };
+		BC3693B1176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369367176D34D700EBE188 /* Makefile */; };
+		BC3693B2176D34D700EBE188 /* OBDeque.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369374176D34D700EBE188 /* OBDeque.h */; };
+		BC3693B3176D34D700EBE188 /* OBInt.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369375176D34D700EBE188 /* OBInt.h */; };
+		BC3693B4176D34D700EBE188 /* OBMap.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369376176D34D700EBE188 /* OBMap.h */; };
+		BC3693B5176D34D700EBE188 /* OBString.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369377176D34D700EBE188 /* OBString.h */; };
+		BC3693B6176D34D700EBE188 /* OBTest.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369378176D34D700EBE188 /* OBTest.h */; };
+		BC3693B7176D34D700EBE188 /* OBVector.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369379176D34D700EBE188 /* OBVector.h */; };
+		BC3693B8176D34D700EBE188 /* offbrand.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36937A176D34D700EBE188 /* offbrand.h */; };
+		BC3693B9176D34D700EBE188 /* OBDeque_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36937C176D34D700EBE188 /* OBDeque_Private.h */; };
+		BC3693BA176D34D700EBE188 /* OBInt_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36937D176D34D700EBE188 /* OBInt_Private.h */; };
+		BC3693BB176D34D700EBE188 /* obj_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36937E176D34D700EBE188 /* obj_Private.h */; };
+		BC3693BC176D34D700EBE188 /* OBMap_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36937F176D34D700EBE188 /* OBMap_Private.h */; };
+		BC3693BD176D34D700EBE188 /* OBString_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369380176D34D700EBE188 /* OBString_Private.h */; };
+		BC3693BE176D34D700EBE188 /* OBTest_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369381176D34D700EBE188 /* OBTest_Private.h */; };
+		BC3693BF176D34D700EBE188 /* OBVector_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BC369382176D34D700EBE188 /* OBVector_Private.h */; };
+		BC3693C0176D34D700EBE188 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = BC369384176D34D700EBE188 /* Makefile */; };
+		BC3693C1176D34D700EBE188 /* PrivateHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36938C176D34D700EBE188 /* PrivateHeader.h */; };
+		BC3693C2176D34D700EBE188 /* PublicHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = BC36938D176D34D700EBE188 /* PublicHeader.h */; };
+		BC3693C5176D34D700EBE188 /* OBDeque.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369392176D34D700EBE188 /* OBDeque.c */; };
+		BC3693C6176D34D700EBE188 /* OBInt.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369393176D34D700EBE188 /* OBInt.c */; };
+		BC3693C7176D34D700EBE188 /* OBMap.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369394176D34D700EBE188 /* OBMap.c */; };
+		BC3693C8176D34D700EBE188 /* OBString.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369395176D34D700EBE188 /* OBString.c */; };
+		BC3693C9176D34D700EBE188 /* OBTest.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369396176D34D700EBE188 /* OBTest.c */; };
+		BC3693CA176D34D700EBE188 /* OBVector.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369397176D34D700EBE188 /* OBVector.c */; };
+		BC3693CB176D34D700EBE188 /* offbrand_stdlib.c in Sources */ = {isa = PBXBuildFile; fileRef = BC369398176D34D700EBE188 /* offbrand_stdlib.c */; };
+		BC3693CC176D34D700EBE188 /* OBDeque_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939A176D34D700EBE188 /* OBDeque_test.c */; };
+		BC3693CD176D34D700EBE188 /* OBInt_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939B176D34D700EBE188 /* OBInt_test.c */; };
+		BC3693CE176D34D700EBE188 /* OBMap_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939C176D34D700EBE188 /* OBMap_test.c */; };
+		BC3693CF176D34D700EBE188 /* OBString_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939D176D34D700EBE188 /* OBString_test.c */; };
+		BC3693D0176D34D700EBE188 /* OBTest_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939E176D34D700EBE188 /* OBTest_test.c */; };
+		BC3693D1176D34D700EBE188 /* OBVector_test.c in Sources */ = {isa = PBXBuildFile; fileRef = BC36939F176D34D700EBE188 /* OBVector_test.c */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BC369342176D34AA00EBE188 /* libOffBrand.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOffBrand.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC36934C176D34D700EBE188 /* minlog_funct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minlog_funct.h; sourceTree = "<group>"; };
+		BC36934D176D34D700EBE188 /* NCube.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCube.h; sourceTree = "<group>"; };
+		BC36934F176D34D700EBE188 /* NCube_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCube_Private.h; sourceTree = "<group>"; };
+		BC369350176D34D700EBE188 /* RTable_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTable_Private.h; sourceTree = "<group>"; };
+		BC369351176D34D700EBE188 /* Term_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Term_Private.h; sourceTree = "<group>"; };
+		BC369352176D34D700EBE188 /* RTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTable.h; sourceTree = "<group>"; };
+		BC369353176D34D700EBE188 /* Term.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Term.h; sourceTree = "<group>"; };
+		BC369354176D34D700EBE188 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		BC369355176D34D700EBE188 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
+		BC369357176D34D700EBE188 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		BC369358176D34D700EBE188 /* package */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = package; sourceTree = "<group>"; };
+		BC369359176D34D700EBE188 /* prepare */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = prepare; sourceTree = "<group>"; };
+		BC36935C176D34D700EBE188 /* NCube.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NCube.c; sourceTree = "<group>"; };
+		BC36935D176D34D700EBE188 /* RTable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = RTable.c; sourceTree = "<group>"; };
+		BC36935E176D34D700EBE188 /* Term.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = Term.c; sourceTree = "<group>"; };
+		BC369360176D34D700EBE188 /* minlog_funct.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = minlog_funct.c; sourceTree = "<group>"; };
+		BC369361176D34D700EBE188 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		BC369363176D34D700EBE188 /* NCube_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NCube_test.c; sourceTree = "<group>"; };
+		BC369364176D34D700EBE188 /* RTable_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = RTable_test.c; sourceTree = "<group>"; };
+		BC369366176D34D700EBE188 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		BC369367176D34D700EBE188 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		BC36936A176D34D700EBE188 /* mainpage.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mainpage.dox; sourceTree = "<group>"; };
+		BC36936B176D34D700EBE188 /* OBDequeModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OBDequeModule.dox; sourceTree = "<group>"; };
+		BC36936C176D34D700EBE188 /* OBIntModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OBIntModule.dox; sourceTree = "<group>"; };
+		BC36936D176D34D700EBE188 /* OBMapModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OBMapModule.dox; sourceTree = "<group>"; };
+		BC36936E176D34D700EBE188 /* OBStringModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OBStringModule.dox; sourceTree = "<group>"; };
+		BC36936F176D34D700EBE188 /* OBTestModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OBTestModule.dox; sourceTree = "<group>"; };
+		BC369370176D34D700EBE188 /* OBVectorModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OBVectorModule.dox; sourceTree = "<group>"; };
+		BC369371176D34D700EBE188 /* stdlib.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = stdlib.dox; sourceTree = "<group>"; };
+		BC369372176D34D700EBE188 /* doxygen.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = doxygen.conf; sourceTree = "<group>"; };
+		BC369374176D34D700EBE188 /* OBDeque.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBDeque.h; sourceTree = "<group>"; };
+		BC369375176D34D700EBE188 /* OBInt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBInt.h; sourceTree = "<group>"; };
+		BC369376176D34D700EBE188 /* OBMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBMap.h; sourceTree = "<group>"; };
+		BC369377176D34D700EBE188 /* OBString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBString.h; sourceTree = "<group>"; };
+		BC369378176D34D700EBE188 /* OBTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBTest.h; sourceTree = "<group>"; };
+		BC369379176D34D700EBE188 /* OBVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBVector.h; sourceTree = "<group>"; };
+		BC36937A176D34D700EBE188 /* offbrand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = offbrand.h; sourceTree = "<group>"; };
+		BC36937C176D34D700EBE188 /* OBDeque_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBDeque_Private.h; sourceTree = "<group>"; };
+		BC36937D176D34D700EBE188 /* OBInt_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBInt_Private.h; sourceTree = "<group>"; };
+		BC36937E176D34D700EBE188 /* obj_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = obj_Private.h; sourceTree = "<group>"; };
+		BC36937F176D34D700EBE188 /* OBMap_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBMap_Private.h; sourceTree = "<group>"; };
+		BC369380176D34D700EBE188 /* OBString_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBString_Private.h; sourceTree = "<group>"; };
+		BC369381176D34D700EBE188 /* OBTest_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBTest_Private.h; sourceTree = "<group>"; };
+		BC369382176D34D700EBE188 /* OBVector_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBVector_Private.h; sourceTree = "<group>"; };
+		BC369383176D34D700EBE188 /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = LICENSE.txt; path = ../LICENSE.txt; sourceTree = "<group>"; };
+		BC369384176D34D700EBE188 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; name = Makefile; path = ../Makefile; sourceTree = "<group>"; };
+		BC369385176D34D700EBE188 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.txt; path = ../README.txt; sourceTree = "<group>"; };
+		BC369387176D34D700EBE188 /* mkobc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = mkobc; sourceTree = "<group>"; };
+		BC369388176D34D700EBE188 /* prepare */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = prepare; sourceTree = "<group>"; };
+		BC369389176D34D700EBE188 /* run_bin */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = run_bin; sourceTree = "<group>"; };
+		BC36938B176D34D700EBE188 /* DocModule.dox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DocModule.dox; sourceTree = "<group>"; };
+		BC36938C176D34D700EBE188 /* PrivateHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrivateHeader.h; sourceTree = "<group>"; };
+		BC36938D176D34D700EBE188 /* PublicHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PublicHeader.h; sourceTree = "<group>"; };
+		BC36938E176D34D700EBE188 /* Source.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = Source.c; sourceTree = "<group>"; };
+		BC36938F176D34D700EBE188 /* Test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = Test.c; sourceTree = "<group>"; };
+		BC369392176D34D700EBE188 /* OBDeque.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBDeque.c; sourceTree = "<group>"; };
+		BC369393176D34D700EBE188 /* OBInt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBInt.c; sourceTree = "<group>"; };
+		BC369394176D34D700EBE188 /* OBMap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBMap.c; sourceTree = "<group>"; };
+		BC369395176D34D700EBE188 /* OBString.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBString.c; sourceTree = "<group>"; };
+		BC369396176D34D700EBE188 /* OBTest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBTest.c; sourceTree = "<group>"; };
+		BC369397176D34D700EBE188 /* OBVector.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBVector.c; sourceTree = "<group>"; };
+		BC369398176D34D700EBE188 /* offbrand_stdlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = offbrand_stdlib.c; sourceTree = "<group>"; };
+		BC36939A176D34D700EBE188 /* OBDeque_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBDeque_test.c; sourceTree = "<group>"; };
+		BC36939B176D34D700EBE188 /* OBInt_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBInt_test.c; sourceTree = "<group>"; };
+		BC36939C176D34D700EBE188 /* OBMap_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBMap_test.c; sourceTree = "<group>"; };
+		BC36939D176D34D700EBE188 /* OBString_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBString_test.c; sourceTree = "<group>"; };
+		BC36939E176D34D700EBE188 /* OBTest_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBTest_test.c; sourceTree = "<group>"; };
+		BC36939F176D34D700EBE188 /* OBVector_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = OBVector_test.c; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BC36933F176D34AA00EBE188 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BC369339176D34AA00EBE188 = {
+			isa = PBXGroup;
+			children = (
+				BC369349176D34D700EBE188 /* apps */,
+				BC369368176D34D700EBE188 /* docs */,
+				BC369373176D34D700EBE188 /* include */,
+				BC369383176D34D700EBE188 /* LICENSE.txt */,
+				BC369384176D34D700EBE188 /* Makefile */,
+				BC369385176D34D700EBE188 /* README.txt */,
+				BC369386176D34D700EBE188 /* scripts */,
+				BC369390176D34D700EBE188 /* src */,
+				BC369343176D34AA00EBE188 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BC369343176D34AA00EBE188 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BC369342176D34AA00EBE188 /* libOffBrand.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BC369349176D34D700EBE188 /* apps */ = {
+			isa = PBXGroup;
+			children = (
+				BC36934A176D34D700EBE188 /* minlog */,
+				BC369365176D34D700EBE188 /* pfinder */,
+			);
+			name = apps;
+			path = ../apps;
+			sourceTree = "<group>";
+		};
+		BC36934A176D34D700EBE188 /* minlog */ = {
+			isa = PBXGroup;
+			children = (
+				BC36934B176D34D700EBE188 /* include */,
+				BC369354176D34D700EBE188 /* Makefile */,
+				BC369355176D34D700EBE188 /* README.txt */,
+				BC369356176D34D700EBE188 /* scripts */,
+				BC36935A176D34D700EBE188 /* src */,
+			);
+			path = minlog;
+			sourceTree = "<group>";
+		};
+		BC36934B176D34D700EBE188 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				BC36934C176D34D700EBE188 /* minlog_funct.h */,
+				BC36934D176D34D700EBE188 /* NCube.h */,
+				BC36934E176D34D700EBE188 /* private */,
+				BC369352176D34D700EBE188 /* RTable.h */,
+				BC369353176D34D700EBE188 /* Term.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		BC36934E176D34D700EBE188 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				BC36934F176D34D700EBE188 /* NCube_Private.h */,
+				BC369350176D34D700EBE188 /* RTable_Private.h */,
+				BC369351176D34D700EBE188 /* Term_Private.h */,
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		BC369356176D34D700EBE188 /* scripts */ = {
+			isa = PBXGroup;
+			children = (
+				BC369357176D34D700EBE188 /* Makefile */,
+				BC369358176D34D700EBE188 /* package */,
+				BC369359176D34D700EBE188 /* prepare */,
+			);
+			path = scripts;
+			sourceTree = "<group>";
+		};
+		BC36935A176D34D700EBE188 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				BC36935B176D34D700EBE188 /* classes */,
+				BC36935F176D34D700EBE188 /* funct */,
+				BC369361176D34D700EBE188 /* main.c */,
+				BC369362176D34D700EBE188 /* tests */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		BC36935B176D34D700EBE188 /* classes */ = {
+			isa = PBXGroup;
+			children = (
+				BC36935C176D34D700EBE188 /* NCube.c */,
+				BC36935D176D34D700EBE188 /* RTable.c */,
+				BC36935E176D34D700EBE188 /* Term.c */,
+			);
+			path = classes;
+			sourceTree = "<group>";
+		};
+		BC36935F176D34D700EBE188 /* funct */ = {
+			isa = PBXGroup;
+			children = (
+				BC369360176D34D700EBE188 /* minlog_funct.c */,
+			);
+			path = funct;
+			sourceTree = "<group>";
+		};
+		BC369362176D34D700EBE188 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				BC369363176D34D700EBE188 /* NCube_test.c */,
+				BC369364176D34D700EBE188 /* RTable_test.c */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		BC369365176D34D700EBE188 /* pfinder */ = {
+			isa = PBXGroup;
+			children = (
+				BC369366176D34D700EBE188 /* main.c */,
+				BC369367176D34D700EBE188 /* Makefile */,
+			);
+			path = pfinder;
+			sourceTree = "<group>";
+		};
+		BC369368176D34D700EBE188 /* docs */ = {
+			isa = PBXGroup;
+			children = (
+				BC369369176D34D700EBE188 /* doxygen */,
+				BC369372176D34D700EBE188 /* doxygen.conf */,
+			);
+			name = docs;
+			path = ../docs;
+			sourceTree = "<group>";
+		};
+		BC369369176D34D700EBE188 /* doxygen */ = {
+			isa = PBXGroup;
+			children = (
+				BC36936A176D34D700EBE188 /* mainpage.dox */,
+				BC36936B176D34D700EBE188 /* OBDequeModule.dox */,
+				BC36936C176D34D700EBE188 /* OBIntModule.dox */,
+				BC36936D176D34D700EBE188 /* OBMapModule.dox */,
+				BC36936E176D34D700EBE188 /* OBStringModule.dox */,
+				BC36936F176D34D700EBE188 /* OBTestModule.dox */,
+				BC369370176D34D700EBE188 /* OBVectorModule.dox */,
+				BC369371176D34D700EBE188 /* stdlib.dox */,
+			);
+			path = doxygen;
+			sourceTree = "<group>";
+		};
+		BC369373176D34D700EBE188 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				BC369374176D34D700EBE188 /* OBDeque.h */,
+				BC369375176D34D700EBE188 /* OBInt.h */,
+				BC369376176D34D700EBE188 /* OBMap.h */,
+				BC369377176D34D700EBE188 /* OBString.h */,
+				BC369378176D34D700EBE188 /* OBTest.h */,
+				BC369379176D34D700EBE188 /* OBVector.h */,
+				BC36937A176D34D700EBE188 /* offbrand.h */,
+				BC36937B176D34D700EBE188 /* private */,
+			);
+			name = include;
+			path = ../include;
+			sourceTree = "<group>";
+		};
+		BC36937B176D34D700EBE188 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				BC36937C176D34D700EBE188 /* OBDeque_Private.h */,
+				BC36937D176D34D700EBE188 /* OBInt_Private.h */,
+				BC36937E176D34D700EBE188 /* obj_Private.h */,
+				BC36937F176D34D700EBE188 /* OBMap_Private.h */,
+				BC369380176D34D700EBE188 /* OBString_Private.h */,
+				BC369381176D34D700EBE188 /* OBTest_Private.h */,
+				BC369382176D34D700EBE188 /* OBVector_Private.h */,
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		BC369386176D34D700EBE188 /* scripts */ = {
+			isa = PBXGroup;
+			children = (
+				BC369387176D34D700EBE188 /* mkobc */,
+				BC369388176D34D700EBE188 /* prepare */,
+				BC369389176D34D700EBE188 /* run_bin */,
+				BC36938A176D34D700EBE188 /* templates */,
+			);
+			name = scripts;
+			path = ../scripts;
+			sourceTree = "<group>";
+		};
+		BC36938A176D34D700EBE188 /* templates */ = {
+			isa = PBXGroup;
+			children = (
+				BC36938B176D34D700EBE188 /* DocModule.dox */,
+				BC36938C176D34D700EBE188 /* PrivateHeader.h */,
+				BC36938D176D34D700EBE188 /* PublicHeader.h */,
+				BC36938E176D34D700EBE188 /* Source.c */,
+				BC36938F176D34D700EBE188 /* Test.c */,
+			);
+			path = templates;
+			sourceTree = "<group>";
+		};
+		BC369390176D34D700EBE188 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				BC369391176D34D700EBE188 /* classes */,
+				BC369398176D34D700EBE188 /* offbrand_stdlib.c */,
+				BC369399176D34D700EBE188 /* tests */,
+			);
+			name = src;
+			path = ../src;
+			sourceTree = "<group>";
+		};
+		BC369391176D34D700EBE188 /* classes */ = {
+			isa = PBXGroup;
+			children = (
+				BC369392176D34D700EBE188 /* OBDeque.c */,
+				BC369393176D34D700EBE188 /* OBInt.c */,
+				BC369394176D34D700EBE188 /* OBMap.c */,
+				BC369395176D34D700EBE188 /* OBString.c */,
+				BC369396176D34D700EBE188 /* OBTest.c */,
+				BC369397176D34D700EBE188 /* OBVector.c */,
+			);
+			path = classes;
+			sourceTree = "<group>";
+		};
+		BC369399176D34D700EBE188 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				BC36939A176D34D700EBE188 /* OBDeque_test.c */,
+				BC36939B176D34D700EBE188 /* OBInt_test.c */,
+				BC36939C176D34D700EBE188 /* OBMap_test.c */,
+				BC36939D176D34D700EBE188 /* OBString_test.c */,
+				BC36939E176D34D700EBE188 /* OBTest_test.c */,
+				BC36939F176D34D700EBE188 /* OBVector_test.c */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BC369340176D34AA00EBE188 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC3693A0176D34D700EBE188 /* minlog_funct.h in Headers */,
+				BC3693A1176D34D700EBE188 /* NCube.h in Headers */,
+				BC3693A2176D34D700EBE188 /* NCube_Private.h in Headers */,
+				BC3693A3176D34D700EBE188 /* RTable_Private.h in Headers */,
+				BC3693A4176D34D700EBE188 /* Term_Private.h in Headers */,
+				BC3693A5176D34D700EBE188 /* RTable.h in Headers */,
+				BC3693A6176D34D700EBE188 /* Term.h in Headers */,
+				BC3693B2176D34D700EBE188 /* OBDeque.h in Headers */,
+				BC3693B3176D34D700EBE188 /* OBInt.h in Headers */,
+				BC3693B4176D34D700EBE188 /* OBMap.h in Headers */,
+				BC3693B5176D34D700EBE188 /* OBString.h in Headers */,
+				BC3693B6176D34D700EBE188 /* OBTest.h in Headers */,
+				BC3693B7176D34D700EBE188 /* OBVector.h in Headers */,
+				BC3693B8176D34D700EBE188 /* offbrand.h in Headers */,
+				BC3693B9176D34D700EBE188 /* OBDeque_Private.h in Headers */,
+				BC3693BA176D34D700EBE188 /* OBInt_Private.h in Headers */,
+				BC3693BB176D34D700EBE188 /* obj_Private.h in Headers */,
+				BC3693BC176D34D700EBE188 /* OBMap_Private.h in Headers */,
+				BC3693BD176D34D700EBE188 /* OBString_Private.h in Headers */,
+				BC3693BE176D34D700EBE188 /* OBTest_Private.h in Headers */,
+				BC3693BF176D34D700EBE188 /* OBVector_Private.h in Headers */,
+				BC3693C1176D34D700EBE188 /* PrivateHeader.h in Headers */,
+				BC3693C2176D34D700EBE188 /* PublicHeader.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		BC369341176D34AA00EBE188 /* OffBrand */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BC369346176D34AA00EBE188 /* Build configuration list for PBXNativeTarget "OffBrand" */;
+			buildPhases = (
+				BC36933E176D34AA00EBE188 /* Sources */,
+				BC36933F176D34AA00EBE188 /* Frameworks */,
+				BC369340176D34AA00EBE188 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OffBrand;
+			productName = OffBrand;
+			productReference = BC369342176D34AA00EBE188 /* libOffBrand.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BC36933A176D34AA00EBE188 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0460;
+				ORGANIZATIONNAME = Softyards;
+			};
+			buildConfigurationList = BC36933D176D34AA00EBE188 /* Build configuration list for PBXProject "OffBrand" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BC369339176D34AA00EBE188;
+			productRefGroup = BC369343176D34AA00EBE188 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BC369341176D34AA00EBE188 /* OffBrand */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BC36933E176D34AA00EBE188 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC3693A7176D34D700EBE188 /* Makefile in Sources */,
+				BC3693A8176D34D700EBE188 /* Makefile in Sources */,
+				BC3693B1176D34D700EBE188 /* Makefile in Sources */,
+				BC3693C0176D34D700EBE188 /* Makefile in Sources */,
+				BC3693C5176D34D700EBE188 /* OBDeque.c in Sources */,
+				BC3693C6176D34D700EBE188 /* OBInt.c in Sources */,
+				BC3693C7176D34D700EBE188 /* OBMap.c in Sources */,
+				BC3693C8176D34D700EBE188 /* OBString.c in Sources */,
+				BC3693C9176D34D700EBE188 /* OBTest.c in Sources */,
+				BC3693CA176D34D700EBE188 /* OBVector.c in Sources */,
+				BC3693CB176D34D700EBE188 /* offbrand_stdlib.c in Sources */,
+				BC3693CC176D34D700EBE188 /* OBDeque_test.c in Sources */,
+				BC3693CD176D34D700EBE188 /* OBInt_test.c in Sources */,
+				BC3693CE176D34D700EBE188 /* OBMap_test.c in Sources */,
+				BC3693CF176D34D700EBE188 /* OBString_test.c in Sources */,
+				BC3693D0176D34D700EBE188 /* OBTest_test.c in Sources */,
+				BC3693D1176D34D700EBE188 /* OBVector_test.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BC369344176D34AA00EBE188 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		BC369345176D34AA00EBE188 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		BC369347176D34AA00EBE188 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EXECUTABLE_PREFIX = lib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		BC369348176D34AA00EBE188 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EXECUTABLE_PREFIX = lib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BC36933D176D34AA00EBE188 /* Build configuration list for PBXProject "OffBrand" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC369344176D34AA00EBE188 /* Debug */,
+				BC369345176D34AA00EBE188 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BC369346176D34AA00EBE188 /* Build configuration list for PBXNativeTarget "OffBrand" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC369347176D34AA00EBE188 /* Debug */,
+				BC369348176D34AA00EBE188 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BC36933A176D34AA00EBE188 /* Project object */;
+}

--- a/OffBrand/OffBrand.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/OffBrand/OffBrand.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:OffBrand.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/OffBrand.xcscheme
+++ b/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/OffBrand.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BC369341176D34AA00EBE188"
+               BuildableName = "libOffBrand.a"
+               BlueprintName = "OffBrand"
+               ReferencedContainer = "container:OffBrand.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/minlog.xcscheme
+++ b/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/minlog.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BCEDDA18177024B200040AE4"
+               BuildableName = "minlog"
+               BlueprintName = "minlog"
+               ReferencedContainer = "container:OffBrand.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BCEDDA18177024B200040AE4"
+            BuildableName = "minlog"
+            BlueprintName = "minlog"
+            ReferencedContainer = "container:OffBrand.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BCEDDA18177024B200040AE4"
+            BuildableName = "minlog"
+            BlueprintName = "minlog"
+            ReferencedContainer = "container:OffBrand.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BCEDDA18177024B200040AE4"
+            BuildableName = "minlog"
+            BlueprintName = "minlog"
+            ReferencedContainer = "container:OffBrand.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/pfinder.xcscheme
+++ b/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/pfinder.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BCEDDA3217702BBF00040AE4"
+               BuildableName = "pfinder"
+               BlueprintName = "pfinder"
+               ReferencedContainer = "container:OffBrand.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BCEDDA3217702BBF00040AE4"
+            BuildableName = "pfinder"
+            BlueprintName = "pfinder"
+            ReferencedContainer = "container:OffBrand.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BCEDDA3217702BBF00040AE4"
+            BuildableName = "pfinder"
+            BlueprintName = "pfinder"
+            ReferencedContainer = "container:OffBrand.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BCEDDA3217702BBF00040AE4"
+            BuildableName = "pfinder"
+            BlueprintName = "pfinder"
+            ReferencedContainer = "container:OffBrand.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -17,6 +17,11 @@
 			<key>primary</key>
 			<true/>
 		</dict>
+		<key>BC7978E4176E12280073143E</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,6 +9,16 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
+		<key>minlog.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+		<key>pfinder.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
 	<dict>
@@ -18,6 +28,16 @@
 			<true/>
 		</dict>
 		<key>BC7978E4176E12280073143E</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>BCEDDA18177024B200040AE4</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>BCEDDA3217702BBF00040AE4</key>
 		<dict>
 			<key>primary</key>
 			<true/>

--- a/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/OffBrand/OffBrand.xcodeproj/xcuserdata/danielhd.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>OffBrand.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>BC369341176D34AA00EBE188</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/apps/minlog/include/private/NCube_Private.h
+++ b/apps/minlog/include/private/NCube_Private.h
@@ -11,7 +11,7 @@
 /* DATA */
 
 struct NCube_struct{
-  obj base;
+  OBObjType base;
   uint32_t *terms;         /* array of all minterms or maxterms  contained in
                               the NCube */
   uint32_t dont_cares;     /* each bit of the uint32_t is associated with a
@@ -31,10 +31,10 @@ NCube * createNCubeWithOrder(uint8_t order);
 
 /* compare two instances of NCube, return 0 if they are equal, 1 if they are not
  * NCubes cannot be considered greater than or less than each other */
-int8_t compareNCubes(const obj *a, const obj *b);
+int8_t compareNCubes(OBTypeRef a, OBTypeRef b);
 
 /* deallocator, frees instance of class back to memory. Should not be called
  * manually, instance will be destroyed when reference count reaches 0 */
-void deallocNCube(obj *to_dealloc);
+void deallocNCube(OBTypeRef to_dealloc);
 
 #endif

--- a/apps/minlog/include/private/RTable_Private.h
+++ b/apps/minlog/include/private/RTable_Private.h
@@ -12,7 +12,7 @@
 /* DATA */
 
 struct RTable_struct{
-  obj base;
+  OBObjType base;
   OBVector *pis;         /* shorthand for Prime Implicants */
   OBVector *terms;
   OBVector *essential_pis;
@@ -28,7 +28,7 @@ struct RTable_struct{
 
 /* deallocator, frees instance of class back to memory. Should not be called
  * manually, instance will be destroyed when reference count reaches 0 */
-void deallocRTable(obj *to_dealloc);
+void deallocRTable(OBTypeRef to_dealloc);
 
 /* used in constructor to determine which Terms covered by which NCubes and
  * which NCubes can be determined to be essential without extra effort */

--- a/apps/minlog/include/private/Term_Private.h
+++ b/apps/minlog/include/private/Term_Private.h
@@ -11,7 +11,7 @@
 /* DATA */
 
 struct Term_struct{
-  obj base;
+  OBObjType base;
   uint32_t term;
 };
 
@@ -20,11 +20,11 @@ struct Term_struct{
 
 /* compare two instances of Term, return 1 if a > b, 0 if a == b, 
  * and -1 if a < b */
-int8_t compareTerms(const obj *a, const obj *b);
+int8_t compareTerms(OBTypeRef a, OBTypeRef b);
 
 /* deallocator, frees instance of class back to memory. Should not be called
  * manually, instance will be destroyed when reference count reaches 0 */
-void deallocTerm(obj *to_dealloc);
+void deallocTerm(OBTypeRef to_dealloc);
 
 
 #endif

--- a/apps/minlog/src/classes/NCube.c
+++ b/apps/minlog/src/classes/NCube.c
@@ -196,7 +196,7 @@ NCube * createNCubeWithOrder(uint8_t order){
   assert(new_cube != NULL);
 
   /* initialize reference counting base data */
-  initBase((obj *)new_cube, &deallocNCube, NULL, &compareNCubes, NULL,
+  OBInitBase(new_cube, &deallocNCube, NULL, &compareNCubes, NULL,
            classname);
 
   new_cube->terms = malloc(sizeof(uint32_t)*(1<<order));
@@ -212,14 +212,14 @@ NCube * createNCubeWithOrder(uint8_t order){
 }
 
 
-int8_t compareNCubes(const obj *a, const obj *b){
+int8_t compareNCubes(OBTypeRef a, OBTypeRef b){
   
   uint32_t i, max_i;
   NCube *comp_a = (NCube *)a;  
   NCube *comp_b = (NCube *)b;  
 
   assert(a != NULL && b != NULL);
-  assert(objIsOfClass(a, "NCube") && objIsOfClass(b, "NCube"));
+  assert(OBObjIsOfClass(a, "NCube") && OBObjIsOfClass(b, "NCube"));
 
   if(comp_a->order != comp_b->order){
     return OB_NOT_EQUAL;
@@ -236,11 +236,11 @@ int8_t compareNCubes(const obj *a, const obj *b){
 }
 
 
-void deallocNCube(obj *to_dealloc){
+void deallocNCube(OBTypeRef to_dealloc){
   /* cast generic obj to NCube */
   NCube *instance = (NCube *)to_dealloc;
   assert(instance != NULL);
-  assert(objIsOfClass(to_dealloc, "NCube"));
+  assert(OBObjIsOfClass(to_dealloc, "NCube"));
   free(instance->terms);
   return;
 }

--- a/apps/minlog/src/classes/Term.c
+++ b/apps/minlog/src/classes/Term.c
@@ -12,7 +12,7 @@ Term * createTerm(uint32_t term){
   assert(new_instance != NULL);
 
   /* initialize reference counting base data */
-  initBase((obj *)new_instance, &deallocTerm, NULL, &compareTerms, NULL, 
+  OBInitBase(new_instance, &deallocTerm, NULL, &compareTerms, NULL,
            classname);
 
   new_instance->term = term;
@@ -26,23 +26,23 @@ uint32_t getTermValue(Term *a){
 
 /* PRIVATE METHODS */
 
-int8_t compareTerms(const obj *a, const obj *b){
+int8_t compareTerms(OBTypeRef a, OBTypeRef b){
   
   Term *comp_a = (Term *)a;  
   Term *comp_b = (Term *)b;  
 
   assert(a != NULL && b != NULL);
-  assert(objIsOfClass(a, "Term") && objIsOfClass(b, "Term"));
+  assert(OBObjIsOfClass(a, "Term") && OBObjIsOfClass(b, "Term"));
 
   if(comp_a->term > comp_b->term) return OB_GREATER_THAN;
   else if(comp_a->term < comp_b->term) return OB_LESS_THAN;
   else return OB_EQUAL_TO;
 }
 
-void deallocTerm(obj *to_dealloc){
+void deallocTerm(OBTypeRef to_dealloc){
   /* cast generic obj to Term */
   Term *instance = (Term *)to_dealloc;
   assert(instance != NULL);
-  assert(objIsOfClass(to_dealloc, "Term"));
+  assert(OBObjIsOfClass(to_dealloc, "Term"));
   return;
 }

--- a/apps/minlog/src/funct/minlog_funct.c
+++ b/apps/minlog/src/funct/minlog_funct.c
@@ -43,8 +43,8 @@ uint8_t parseEqnString(const char *eqnstr, OBVector *terms,
   assert(regcomp(&sop_regex, "m", REG_EXTENDED) == 0);
 
   /* clear vectors of terms and dont_cares */
-  clearVector(terms);
-  clearVector(dont_cares);
+  OBVectorClear(terms);
+  OBVectorClear(dont_cares);
 
   /* determine where terms and dont cares are located in the string */
   if(!regexec(&dc_regex, eqnstr, 1, &match, REG_NOTBOL|REG_NOTEOL))
@@ -94,8 +94,8 @@ uint8_t parseEqnString(const char *eqnstr, OBVector *terms,
     cur_term_int = atoi(cur_term);
 
     new_term_obj = createTerm(cur_term_int);
-    storeAtVectorIndex(terms,(obj *)new_term_obj, vectorLength(terms));
-    release((obj *)new_term_obj);
+    OBVectorStoreAtIndex(terms,new_term_obj, OBVectorGetLength(terms));
+    OBRelease(new_term_obj);
 
     curhead += match.rm_eo;
   }
@@ -111,9 +111,9 @@ uint8_t parseEqnString(const char *eqnstr, OBVector *terms,
       cur_term_int = atoi(cur_term);
 
       new_term_obj = createTerm(cur_term_int);
-      storeAtVectorIndex(dont_cares, (obj *)new_term_obj, 
-                         vectorLength(dont_cares));
-      release((obj *)new_term_obj);
+      OBVectorStoreAtIndex(dont_cares, new_term_obj,
+                         OBVectorGetLength(dont_cares));
+      OBRelease(new_term_obj);
 
       curhead += match.rm_eo;
     }
@@ -126,7 +126,7 @@ uint8_t parseEqnString(const char *eqnstr, OBVector *terms,
   regfree(&sop_regex);
 
   /* check that some terms were read in */
-  if(vectorLength(terms) == 0){
+  if(OBVectorGetLength(terms) == 0){
     fprintf(stderr, "minlog:parseEqnStr - No terms supplied in the "
                     "equation,\nProgram exits due to bad equation format\n");
     exit(1);
@@ -137,16 +137,16 @@ uint8_t parseEqnString(const char *eqnstr, OBVector *terms,
 
     if(retval == MINLOG_MINTERMS) printf("Minterms parsed from equation:\n");
     else printf("Maxterms parsed from equation:\n");
-    for(i=0; i<vectorLength(terms); i++){
-      printf("%u\n", getTermValue((Term *)objAtVectorIndex(terms, i)));
+    for(i=0; i<OBVectorGetLength(terms); i++){
+      printf("%u\n", getTermValue((Term *)OBVectorObjectAtIndex(terms, i)));
     }
 
     printf("\n");
 
-    if(vectorLength(dont_cares) > 0){
+    if(OBVectorGetLength(dont_cares) > 0){
       printf("Dont cares parsed from equation:\n");
-      for(i=0; i<vectorLength(dont_cares); i++){
-        printf("%u\n", getTermValue((Term *)objAtVectorIndex(dont_cares, i)));
+      for(i=0; i<OBVectorGetLength(dont_cares); i++){
+        printf("%u\n", getTermValue((Term *)OBVectorObjectAtIndex(dont_cares, i)));
       }
     }
     else printf("Without any dont care terms\n");
@@ -165,63 +165,63 @@ OBVector * findLargestPrimeImplicants(const OBVector *terms,
   NCube *tmp_cube, *a, *b;
   Term *tmp_term;
 
-  assert(terms != NULL && vectorLength(terms) != 0);
+  assert(terms != NULL && OBVectorGetLength(terms) != 0);
 
-  maxi = vectorLength(terms);
+  maxi = OBVectorGetLength(terms);
 
   /* create vector for 0 cubes */
-  cur_cube_vector = createVector(vectorLength(terms)+vectorLength(dont_cares));
+  cur_cube_vector = OBVectorCreateWithCapacity(OBVectorGetLength(terms)+OBVectorGetLength(dont_cares));
 
   /* create all cubes associated with terms */
   for(i=0; i<maxi; i++){
     /* get term for cube creation */
-    tmp_term = (Term *)objAtVectorIndex(terms, i);
-    assert(objIsOfClass((obj *)tmp_term, "Term"));
+    tmp_term = (Term *)OBVectorObjectAtIndex(terms, i);
+    assert(OBObjIsOfClass(tmp_term, "Term"));
 
     /* create cube from term, which is not a dont care cube */
     tmp_cube = createNCube(getTermValue(tmp_term), 0);
 
     /* add cube to cur_cube_vector */
-    storeAtVectorIndex(cur_cube_vector, (obj *)tmp_cube, 
-                       vectorLength(cur_cube_vector));
+    OBVectorStoreAtIndex(cur_cube_vector, tmp_cube,
+                       OBVectorGetLength(cur_cube_vector));
 
     /* release tmp_cube so only vector maintains valid reference */
-    release((obj *)tmp_cube);
+    OBRelease(tmp_cube);
   }
 
   /* if dont_care terms are supplied, create cubes for them */
   if(dont_cares){
 
-    maxi = vectorLength(dont_cares);
+    maxi = OBVectorGetLength(dont_cares);
 
     for(i=0; i<maxi; i++){
       /* get term for cube creation */
-      tmp_term = (Term *)objAtVectorIndex(dont_cares, i);
-      assert(objIsOfClass((obj *)tmp_term, "Term"));
+      tmp_term = (Term *)OBVectorObjectAtIndex(dont_cares, i);
+      assert(OBObjIsOfClass(tmp_term, "Term"));
 
       /* create cube from term, which is not a dont care cube */
       tmp_cube = createNCube(getTermValue(tmp_term), 1);
 
       /* add cube to cur_cube_vector */
-      storeAtVectorIndex(cur_cube_vector, (obj *)tmp_cube,
-                         vectorLength(cur_cube_vector));
+      OBVectorStoreAtIndex(cur_cube_vector, tmp_cube,
+                         OBVectorGetLength(cur_cube_vector));
 
       /* release tmp_cube so only vector maintains valid reference */
-      release((obj *)tmp_cube);
+      OBRelease(tmp_cube);
     }
   }
 
 
   /* create vector to contain vectors of NCubes (each sub vector contains cubes
    * of all the same order) */
-  cube_vectors = createVector(1);
+  cube_vectors = OBVectorCreateWithCapacity(1);
   
   /* add 0 cube vector to vector of vectors */
-  storeAtVectorIndex(cube_vectors, (obj *)cur_cube_vector, 
-                     vectorLength(cube_vectors));
+  OBVectorStoreAtIndex(cube_vectors, cur_cube_vector,
+                     OBVectorGetLength(cube_vectors));
 
   /* release cur_cube_vector so only cube_vectors maintains valid reference */
-  release((obj *)cur_cube_vector);
+  OBRelease(cur_cube_vector);
 
   /* while cubes can still be merged into larger cubes */
   k = 0;
@@ -233,62 +233,62 @@ OBVector * findLargestPrimeImplicants(const OBVector *terms,
     loop = -1; 
 
     /* get previous cube vector, and create new vector for next order of cubes*/
-    prev_cube_vector = (OBVector *)objAtVectorIndex(cube_vectors, k);
-    cur_cube_vector = createVector(vectorLength(prev_cube_vector)/4);
+    prev_cube_vector = (OBVector *)OBVectorObjectAtIndex(cube_vectors, k);
+    cur_cube_vector = OBVectorCreateWithCapacity(OBVectorGetLength(prev_cube_vector)/4);
 
     /* for all pairs cubes, attempt to merge */
-    maxi = vectorLength(prev_cube_vector);
+    maxi = OBVectorGetLength(prev_cube_vector);
     for(i=0; i<maxi-1; i++){
 
-      a = (NCube *)objAtVectorIndex(prev_cube_vector, i);
+      a = (NCube *)OBVectorObjectAtIndex(prev_cube_vector, i);
 
       for(j=i+1; j<maxi; j++){
 
-        b = (NCube *)objAtVectorIndex(prev_cube_vector, j);
+        b = (NCube *)OBVectorObjectAtIndex(prev_cube_vector, j);
         /*if cubes can be merged */
 
         /* if the cubes can be merged, and an equivalent cube is not already in
          * the cur cube vector */
         if((tmp_cube = mergeNCubes(a, b))){
-          if(!findObjInVector(cur_cube_vector,(obj *)tmp_cube)){
-            storeAtVectorIndex(cur_cube_vector, (obj *)tmp_cube,
-                               vectorLength(cur_cube_vector));
+          if(!OBVectorContains(cur_cube_vector,tmp_cube)){
+            OBVectorStoreAtIndex(cur_cube_vector, tmp_cube,
+                               OBVectorGetLength(cur_cube_vector));
             /* increment loop to indicate that larger cube was created */
             loop++;
           } 
           /* release tmp_cube whether or not it was added to the vector, either
            * freeing or leaving vector with only valid reference */
-          release((obj *)tmp_cube);
+          OBRelease(tmp_cube);
         }
       }
     }
     
-    storeAtVectorIndex(cube_vectors, (obj *)cur_cube_vector,
-                       vectorLength(cube_vectors));
+    OBVectorStoreAtIndex(cube_vectors, cur_cube_vector,
+                       OBVectorGetLength(cube_vectors));
     /* release cur_cube_vector so cube_vectors maintains only valid reference */
-    release((obj *)cur_cube_vector);
+    OBRelease(cur_cube_vector);
     /* increment k to work on next order of cube vectors */
     k++;
   }
 
   /* Create final vector of only prime implicant cubes */
-  result = createVector(1);
+  result = OBVectorCreateWithCapacity(1);
 
-  maxi = vectorLength(cube_vectors);
+  maxi = OBVectorGetLength(cube_vectors);
   for(i=0; i<maxi; i++){
     
-    cur_cube_vector = (OBVector *)objAtVectorIndex(cube_vectors, i);
-    maxj = vectorLength(cur_cube_vector);
+    cur_cube_vector = (OBVector *)OBVectorObjectAtIndex(cube_vectors, i);
+    maxj = OBVectorGetLength(cur_cube_vector);
 
     for(j=0; j<maxj; j++){
-      tmp_cube = (NCube *)objAtVectorIndex(cur_cube_vector, j);
+      tmp_cube = (NCube *)OBVectorObjectAtIndex(cur_cube_vector, j);
       if(isNCubePrimeImplicant(tmp_cube)){
-        storeAtVectorIndex(result, (obj *)tmp_cube, vectorLength(result));
+        OBVectorStoreAtIndex(result, tmp_cube, OBVectorGetLength(result));
       }
     }
   }
 
-  release((obj *)cube_vectors);
+  OBRelease(cube_vectors);
   return result;
 }
 
@@ -299,16 +299,16 @@ void printEqnVector(const OBVector *essential_pis, uint8_t is_sop,
   char *cubestr;
 
   printf("\nReduced Equation:\n");
-  for(i=0; i<vectorLength(essential_pis); i++){
+  for(i=0; i<OBVectorGetLength(essential_pis); i++){
 
-    assert(objIsOfClass(objAtVectorIndex(essential_pis, i), "NCube"));
-    cubestr = nCubeStr((NCube *)objAtVectorIndex(essential_pis, i), is_sop,
+    assert(OBObjIsOfClass(OBVectorObjectAtIndex(essential_pis, i), "NCube"));
+    cubestr = nCubeStr((NCube *)OBVectorObjectAtIndex(essential_pis, i), is_sop,
                         num_var);
     printf("%s", cubestr);
     free(cubestr);
     
     /* if printing terms in sum of products, print '+' in proper places */
-    if(is_sop && i != vectorLength(essential_pis)-1) printf("+");
+    if(is_sop && i != OBVectorGetLength(essential_pis)-1) printf("+");
   }
 
   printf("\n");

--- a/apps/minlog/src/main.c
+++ b/apps/minlog/src/main.c
@@ -12,7 +12,8 @@ int main(int argc, char **argv){
   OBVector *terms, *dont_cares, *pis, *essential_pis;
   RTable *reduction_table;
   uint8_t is_minterms, num_var;
-  uint32_t max_term, numchar, substrlen; 
+  uint32_t max_term, numchar;
+  size_t substrlen;
   int i;
   char eqnstr[MAX_EQN_SIZE];
 
@@ -58,8 +59,8 @@ int main(int argc, char **argv){
   }
   eqnstr[numchar] = '\0'; /* add null terminator to string */
     
-  terms = createVector(32);
-  dont_cares = createVector(32);
+  terms = OBVectorCreateWithCapacity(32);
+  dont_cares = OBVectorCreateWithCapacity(32);
 
 
   /* parse verbosely for testing */
@@ -67,8 +68,8 @@ int main(int argc, char **argv){
 
   /* find largest term, found by sorting and picking first term. Inefficient but
    * concise compared to iterating through each term and checking results */
-  sortVector(terms, OB_GREATEST_TO_LEAST);
-  max_term = getTermValue((Term *)objAtVectorIndex(terms, 0));
+  OBVectorSort(terms, OB_GREATEST_TO_LEAST);
+  max_term = getTermValue((Term *)OBVectorObjectAtIndex(terms, 0));
   num_var = 0;
   /* increase number of variables until 2^num_var > max_term */
   while(1u<<num_var <= max_term) num_var++;
@@ -76,24 +77,24 @@ int main(int argc, char **argv){
   /* find prime implicants */
   pis = findLargestPrimeImplicants(terms, dont_cares);
 
-  dont_cares = (OBVector *)release((obj *)dont_cares);
+  dont_cares = (OBVector *)OBRelease(dont_cares);
 
   /* create the table used to reduce the prime implicants to the minimal
    * essential prime implicants */
   reduction_table = createRTable(pis, terms);
   
-  terms = (OBVector *)release((obj *)terms);
-  pis = (OBVector *)release((obj *)pis);
+  terms = (OBVector *)OBRelease(terms);
+  pis = (OBVector *)OBRelease(pis);
 
   /* find the minimal function representation */
   essential_pis = findEssentialPIs(reduction_table, num_var); 
 
-  reduction_table = (RTable *)release((obj *)reduction_table);
+  reduction_table = (RTable *)OBRelease(reduction_table);
   
   /* print the result to stdout */
   printEqnVector(essential_pis, !is_minterms, num_var);
 
-  essential_pis = (OBVector *)release((obj *)essential_pis);
+  essential_pis = (OBVector *)OBRelease(essential_pis);
 
   return 0;
 }

--- a/apps/pfinder/main.c
+++ b/apps/pfinder/main.c
@@ -11,47 +11,47 @@ int main(){
   OBVector *primes;
 
   // create vector with a small initial capacity
-  primes = createVector(1);
+  primes = OBVectorCreateWithCapacity(1);
 
   // seed primes vector with initial prime 2. Note the cast of 
   // the OBInt to obj, an OBVector stores the generic obj type rather than
   // any specific type
-  candidate = createIntWithInt(2);
-  storeAtVectorIndex(primes, (obj *)candidate, 0);
+  candidate = OBIntCreate(2);
+  OBVectorStoreAtIndex(primes, candidate, 0);
 
   // release the candidate so the vector maintains the only reference to the
   // prime number. release operates on the generic obj type, so the pointer
   // is cast
-  release((obj *)candidate);
+  OBRelease(candidate);
 
   // begin the main prime finding loop
-  candidate = createIntWithInt(3);
+  candidate = OBIntCreate(3);
   while(1){
 
     maybe_prime = 1;
 
     // search for a prime factor of candidate
-    for(i=0; i<vectorLength(primes); i++){
-      remainder = modInts(candidate, (OBInt *)objAtVectorIndex(primes, i));
+    for(i=0; i<OBVectorGetLength(primes); i++){
+      remainder = OBIntMod(candidate, (OBInt *)OBVectorObjectAtIndex(primes, i));
       // if the remainder is 0 then the candidate number is not prime
-      if(isIntZero(remainder)) maybe_prime = 0;
-      release((obj *)remainder);
+      if(OBIntIsZero(remainder)) maybe_prime = 0;
+      OBRelease(remainder);
       if(!maybe_prime) break;
     }
 
     // if the number is still maybe prime then it is now definitely prime,
     // add it to the end of the primes vector
     if(maybe_prime){
-      storeAtVectorIndex(primes, (obj *)candidate, vectorLength(primes));
-      numstr = stringFromInt(candidate);
-      printf("Prime found: %s\n", getCString(numstr));
-      release((obj *)numstr);
+      OBVectorStoreAtIndex(primes, candidate, OBVectorGetLength(primes));
+      numstr = OBIntGetStringValue(candidate);
+      printf("Prime found: %s\n", OBStringGetCString(numstr));
+      OBRelease(numstr);
     }
 
     // increment candidate by 2 and release old candidate, it is not needed
     // by main loop
-    next = addIntAndPrim(candidate, 2); 
-    release((obj *)candidate);
+    next = OBIntAddPrimitive(candidate, 2);
+    OBRelease(candidate);
     candidate = next;
   }
 }

--- a/docs/doxygen/mainpage.dox
+++ b/docs/doxygen/mainpage.dox
@@ -102,12 +102,12 @@
     // the OBInt to obj, an OBVector stores the generic obj type rather than
     // any specific type
     candidate = createIntWithInt(2);
-    storeAtVectorIndex(primes, (obj *)candidate, 0);
+    storeAtVectorIndex(primes, candidate, 0);
   
     // release the candidate so the vector maintains the only reference to the
     // prime number. release operates on the generic obj type, so the pointer
     // is cast
-    release((obj *)candidate);
+    release(candidate);
   
     // begin the main prime finding loop
     candidate = createIntWithInt(3);
@@ -120,23 +120,23 @@
         remainder = modInts(candidate, (OBInt *)objAtVectorIndex(primes, i));
         // if the remainder is 0 then the candidate number is not prime
         if(isIntZero(remainder)) maybe_prime = 0;
-        release((obj *)remainder);
+        release(remainder);
         if(!maybe_prime) break;
       }
   
       // if the number is still maybe prime then it is now definitely prime,
       // add it to the end of the primes vector
       if(maybe_prime){
-        storeAtVectorIndex(primes, (obj *)candidate, vectorLength(primes));
+        storeAtVectorIndex(primes, candidate, vectorLength(primes));
         numstr = stringFromInt(candidate);
         printf("Prime found: %s\n", getCString(numstr));
-        release((obj *)numstr);
+        release(numstr);
       }
   
       // increment candidate by 2 and release old candidate, it is not needed
       // by main loop
       next = addIntAndPrim(candidate, 2); 
-      release((obj *)candidate);
+      release(candidate);
       candidate = next;
     }
   }

--- a/include/OBDeque.h
+++ b/include/OBDeque.h
@@ -196,7 +196,7 @@ void sortDeque(OBDeque *deque, int8_t order);
  * @param funct A pointer to a comparision function that returns a int8_t when
  * given two obj * arguments
  */
-void sortDequeWithFunct(OBDeque *deque, int8_t order, compare_fptr funct);
+void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct);
 
 /**
  * @brief Peek at the obj stored at the head of an OBDeque

--- a/include/OBDeque.h
+++ b/include/OBDeque.h
@@ -129,7 +129,7 @@ uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it);
  * @param deque An instance of OBDeque
  * @param to_add Any instance of an Offbrand compatible class to add to deque
  */
-void addDequeHead(OBDeque *deque, obj *to_add);
+void addDequeHead(OBDeque *deque, OBObjType *to_add);
 
 /**
  * @brief Add an obj to the tail of an OBDeque
@@ -137,7 +137,7 @@ void addDequeHead(OBDeque *deque, obj *to_add);
  * @param deque An instance of OBDeque
  * @param to_add Any instance of an Offbrand compatible class to add to deque
  */
-void addDequeTail(OBDeque *deque, obj *to_add);
+void addDequeTail(OBDeque *deque, OBObjType *to_add);
 
 /**
  * @brief Add an obj to an OBDeque at position before the element specified by
@@ -147,7 +147,7 @@ void addDequeTail(OBDeque *deque, obj *to_add);
  * @param it An instance of OBDequeIterator bound to deque
  * @param to_add Any instance of an Offbrand compatible class to add to deque
  */
-void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, obj *to_add);
+void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add);
 
 /**
  * @brief creates a new OBDeque that contains the ordered contents of two 
@@ -170,7 +170,7 @@ OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2);
  * @retval 0 to_find not found within deque
  * @retval 1 to_find found within the deque
  */
-uint8_t findObjInDeque(const OBDeque *deque, const obj *to_find);
+uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find);
 
 /**
  * @brief Sorts an OBDeque from least-to-greatest or greatest-to-least using
@@ -206,7 +206,7 @@ void sortDequeWithFunct(OBDeque *deque, int8_t order, compare_fptr funct);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the head of deque
  */
-obj * objAtDequeHead(const OBDeque *deque);
+OBObjType * objAtDequeHead(const OBDeque *deque);
 
 /**
  * @brief Peek at the obj stored at the tail of an OBDeque
@@ -216,7 +216,7 @@ obj * objAtDequeHead(const OBDeque *deque);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the tail of deque
  */
-obj * objAtDequeTail(const OBDeque *deque);
+OBObjType * objAtDequeTail(const OBDeque *deque);
 
 /**
  * @brief Peek at the obj stored within a OBDeque stored at the position denoted
@@ -228,7 +228,7 @@ obj * objAtDequeTail(const OBDeque *deque);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the tail of deque
  */
-obj * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it);
+OBObjType * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it);
 
 
 /**

--- a/include/OBDeque.h
+++ b/include/OBDeque.h
@@ -23,7 +23,7 @@ typedef struct OBDequeIterator_struct OBDequeIterator;
  * @brief Constructor, creates a new instance of OBDeque with no contents
  * @return Pointer to a newly created and initialized instance of OBDeque
  */
-OBDeque * createDeque(void);
+OBDeque * OBDequeCreate(void);
 
 /**
  * @brief Copy Constructor, creates a new OBDeque that contains the same
@@ -33,7 +33,7 @@ OBDeque * createDeque(void);
  *
  * @return Pointer to a newly created and initialized instance of OBDeque
  */
-OBDeque * copyDeque(const OBDeque *to_copy);
+OBDeque * OBDequeCopy(const OBDeque *to_copy);
 
 /**
  * @brief The emptyness state of an OBDeque, either empty or non-empty
@@ -43,7 +43,7 @@ OBDeque * copyDeque(const OBDeque *to_copy);
  * @retval 0 The deque is empty
  * @retval non-zero The deque contains elements
  */
-uint8_t isDequeEmpty(const OBDeque *deque);
+uint8_t OBDequeIsEmpty(const OBDeque *deque);
 
 /**
  * @brief Number of elements stored within an OBDeque
@@ -52,7 +52,7 @@ uint8_t isDequeEmpty(const OBDeque *deque);
  *
  * @return An integer corresponding the the number of objects in the deque
  */
-uint64_t dequeLength(const OBDeque *deque);
+uint64_t OBDequeLength(const OBDeque *deque);
 
 /**
  * @brief Constructor for an iterator for an OBDeque that is directed at the
@@ -67,7 +67,7 @@ uint64_t dequeLength(const OBDeque *deque);
  * @warning The OBDequeIterator created by this method MUST be released by the
  * user, else a memory leak will occur
  */
-OBDequeIterator * getDequeHeadIt(const OBDeque *deque);
+OBDequeIterator * OBDequeGetHeadIterator(const OBDeque *deque);
 
 /**
  * @brief Constructor for an iterator for an OBDeque that is directed at the
@@ -82,7 +82,7 @@ OBDequeIterator * getDequeHeadIt(const OBDeque *deque);
  * @warning The OBDequeIterator created by this method MUST be released by the
  * user, else a memory leak will occur
  */
-OBDequeIterator * getDequeTailIt(const OBDeque *deque);
+OBDequeIterator * OBDequeGetTailIterator(const OBDeque *deque);
 
 /**
  * @brief Copy Constructor for an OBDequeIterator from another OBDequeIterator
@@ -95,7 +95,7 @@ OBDequeIterator * getDequeTailIt(const OBDeque *deque);
  * @warning The OBDequeIterator created by this method MUST be released by the
  * user, else a memory leak will occur
  */
-OBDequeIterator * copyDequeIterator(const OBDequeIterator *it);
+OBDequeIterator * OBDequeIteratorCopy(const OBDequeIterator *it);
 
 /**
  * @brief Advance an OBDequeIterator bound to an OBDeque to the next element
@@ -108,7 +108,7 @@ OBDequeIterator * copyDequeIterator(const OBDequeIterator *it);
  * @retval 0 Advancement failed because no more elements exist in the OBDeque
  * closer to the deque tail
  */
-uint8_t iterateDequeNext(const OBDeque *deque, OBDequeIterator *it);
+uint8_t OBDequeIterateNext(const OBDeque *deque, OBDequeIterator *it);
 
 /**
  * @brief Advance an OBDequeIterator bound to an OBDeque to the previous element
@@ -121,7 +121,7 @@ uint8_t iterateDequeNext(const OBDeque *deque, OBDequeIterator *it);
  * @retval 0 Advancement failed because no more elements exist in the OBDeque
  * closer to the deque head
  */
-uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it);
+uint8_t OBDequeIteratePrevious(const OBDeque *deque, OBDequeIterator *it);
 
 /**
  * @brief Add an obj to the head of an OBDeque
@@ -129,7 +129,7 @@ uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it);
  * @param deque An instance of OBDeque
  * @param to_add Any instance of an Offbrand compatible class to add to deque
  */
-void addDequeHead(OBDeque *deque, OBObjType *to_add);
+void OBDequeAddHead(OBDeque *deque, OBTypeRef to_add);
 
 /**
  * @brief Add an obj to the tail of an OBDeque
@@ -137,7 +137,7 @@ void addDequeHead(OBDeque *deque, OBObjType *to_add);
  * @param deque An instance of OBDeque
  * @param to_add Any instance of an Offbrand compatible class to add to deque
  */
-void addDequeTail(OBDeque *deque, OBObjType *to_add);
+void OBDequeAddTail(OBDeque *deque, OBTypeRef to_add);
 
 /**
  * @brief Add an obj to an OBDeque at position before the element specified by
@@ -147,7 +147,7 @@ void addDequeTail(OBDeque *deque, OBObjType *to_add);
  * @param it An instance of OBDequeIterator bound to deque
  * @param to_add Any instance of an Offbrand compatible class to add to deque
  */
-void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add);
+void OBDeuqueAddAtIterator(OBDeque *deque, OBDequeIterator *it, OBTypeRef to_add);
 
 /**
  * @brief creates a new OBDeque that contains the ordered contents of two 
@@ -158,7 +158,7 @@ void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add);
  *
  * @return An OBDeque instance that contains the contents of d1 followed by d2
  */
-OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2);
+OBDeque * OBDequeJoin(const OBDeque *d1, const OBDeque *d2);
 
 /**
  * @brief Searches an OBDeque for an obj
@@ -170,7 +170,7 @@ OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2);
  * @retval 0 to_find not found within deque
  * @retval 1 to_find found within the deque
  */
-uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find);
+uint8_t OBDequeContains(const OBDeque *deque, OBTypeRef to_find);
 
 /**
  * @brief Sorts an OBDeque from least-to-greatest or greatest-to-least using
@@ -184,7 +184,7 @@ uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find);
  * compatible classes the call will likely not sort members in any expected
  * order, but will reorder components
  */
-void sortDeque(OBDeque *deque, int8_t order);
+void OBDequeSort(OBDeque *deque, int8_t order);
 
 /**
  * @brief Sorts an OBDeque from least-to-greatest or greatest-to-least using
@@ -196,7 +196,7 @@ void sortDeque(OBDeque *deque, int8_t order);
  * @param funct A pointer to a comparision function that returns a int8_t when
  * given two obj * arguments
  */
-void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct);
+void OBDequeSortWithFunction(OBDeque *deque, int8_t order, obcompare_fptr funct);
 
 /**
  * @brief Peek at the obj stored at the head of an OBDeque
@@ -206,7 +206,7 @@ void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the head of deque
  */
-OBObjType * objAtDequeHead(const OBDeque *deque);
+OBTypeRef OBDequeFirstObject(const OBDeque *deque);
 
 /**
  * @brief Peek at the obj stored at the tail of an OBDeque
@@ -216,7 +216,7 @@ OBObjType * objAtDequeHead(const OBDeque *deque);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the tail of deque
  */
-OBObjType * objAtDequeTail(const OBDeque *deque);
+OBTypeRef OBDequeLastObject(const OBDeque *deque);
 
 /**
  * @brief Peek at the obj stored within a OBDeque stored at the position denoted
@@ -228,7 +228,7 @@ OBObjType * objAtDequeTail(const OBDeque *deque);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the tail of deque
  */
-OBObjType * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it);
+OBTypeRef OBDequeObjAtIterator(const OBDeque *deque, const OBDequeIterator *it);
 
 
 /**
@@ -236,14 +236,14 @@ OBObjType * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it);
  * by one element
  * @param deque An instance of OBDeque
  */
-void removeDequeHead(OBDeque *deque);
+void OBDequeRemoveFirstObject(OBDeque *deque);
 
 /**
  * @brief Remove the obj stored at the tail of an OBDeque, shrinking the OBDeque
  * by one element
  * @param deque An instance of OBDeque
  */
-void removeDequeTail(OBDeque *deque);
+void OBDequeRemoveLastObject(OBDeque *deque);
 
 /**
  * @brief Remove the obj stored within an OBDeque at the position denoted by the
@@ -256,12 +256,12 @@ void removeDequeTail(OBDeque *deque);
  * tail, unless removing the tail then it will be advanced to the element before
  * the tail (NULL if no more elements exist)
  */
-void removeDequeAtIt(OBDeque *deque, OBDequeIterator *it);
+void OBDequeRemoveAtIterator(OBDeque *deque, OBDequeIterator *it);
 
 /**
  * @brief removes all obj's from the Deque, leaving the Deque empty
  * @param deque An instance of OBDeque
  */
-void clearDeque(OBDeque *deque);
+void OBDequeClear(OBDeque *deque);
 
 #endif

--- a/include/OBDeque.h
+++ b/include/OBDeque.h
@@ -52,7 +52,7 @@ uint8_t OBDequeIsEmpty(const OBDeque *deque);
  *
  * @return An integer corresponding the the number of objects in the deque
  */
-uint64_t OBDequeLength(const OBDeque *deque);
+uint64_t OBDequeGetLength(const OBDeque *deque);
 
 /**
  * @brief Constructor for an iterator for an OBDeque that is directed at the
@@ -206,7 +206,7 @@ void OBDequeSortWithFunction(OBDeque *deque, int8_t order, obcompare_fptr funct)
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the head of deque
  */
-OBTypeRef OBDequeFirstObject(const OBDeque *deque);
+OBTypeRef OBDequeGetFirstObject(const OBDeque *deque);
 
 /**
  * @brief Peek at the obj stored at the tail of an OBDeque
@@ -216,7 +216,7 @@ OBTypeRef OBDequeFirstObject(const OBDeque *deque);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the tail of deque
  */
-OBTypeRef OBDequeLastObject(const OBDeque *deque);
+OBTypeRef OBDequeGetLastObject(const OBDeque *deque);
 
 /**
  * @brief Peek at the obj stored within a OBDeque stored at the position denoted
@@ -228,7 +228,7 @@ OBTypeRef OBDequeLastObject(const OBDeque *deque);
  * @retval NULL No elements exist within deque
  * @retval non-NULL The element stored at the tail of deque
  */
-OBTypeRef OBDequeObjAtIterator(const OBDeque *deque, const OBDequeIterator *it);
+OBTypeRef OBDequeGetObjectAtIterator(const OBDeque *deque, const OBDequeIterator *it);
 
 
 /**
@@ -256,7 +256,7 @@ void OBDequeRemoveLastObject(OBDeque *deque);
  * tail, unless removing the tail then it will be advanced to the element before
  * the tail (NULL if no more elements exist)
  */
-void OBDequeRemoveAtIterator(OBDeque *deque, OBDequeIterator *it);
+void OBDequeRemoveObjectAtIterator(OBDeque *deque, OBDequeIterator *it);
 
 /**
  * @brief removes all obj's from the Deque, leaving the Deque empty

--- a/include/OBInt.h
+++ b/include/OBInt.h
@@ -23,7 +23,7 @@ typedef struct OBInt_struct OBInt;
  *
  * @return An instance of OBInt with value given by num
  */
-OBInt * createIntWithInt(int64_t num);
+OBInt * OBIntCreate(int64_t num);
 
 /**
  * @brief Returns the value stored in OBInt as an integer
@@ -35,7 +35,7 @@ OBInt * createIntWithInt(int64_t num);
  * @warning If the value of the OBInt cannot be represented in 64 bits then
  * returned value will not represent the true value of the OBInt
  */
-int64_t intValue(const OBInt *a);
+int64_t OBIntGetIntValue(const OBInt *a);
 
 /**
  * @brief Creates a new OBInt with value indicated by given string
@@ -46,7 +46,7 @@ int64_t intValue(const OBInt *a);
  *
  * @return An instance of OBInt with value given by numstr
  */
-OBInt * intFromString(const OBString *numstr);
+OBInt * OBIntCreateFromString(const OBString *numstr);
 
 /**
  * @brief Creates an instance of OBString containing a string representation
@@ -56,7 +56,7 @@ OBInt * intFromString(const OBString *numstr);
  *
  * @return An instance of OBString
  */
-OBString * stringFromInt(const OBInt *a);
+OBString * OBIntGetStringValue(const OBInt *a);
 
 /**
  * @brief Creates an instance of OBInt with the same value as the argument
@@ -66,7 +66,7 @@ OBString * stringFromInt(const OBInt *a);
  *
  * @return A copy of the argument OBInt
  */
-OBInt * copyInt(const OBInt *a);
+OBInt * OBIntCopy(const OBInt *a);
 
 /**
  * @brief Checks if an instance of OBInt is zero and returns the boolean truth
@@ -77,7 +77,7 @@ OBInt * copyInt(const OBInt *a);
  * @retval 0 The argument is non-zero
  * @retval non-zero The argument is zero
  */
-uint8_t isIntZero(const OBInt *a);
+uint8_t OBIntIsZero(const OBInt *a);
 
 /**
  * @brief Checks if an instance of OBInt is negative and returns the boolean
@@ -88,7 +88,7 @@ uint8_t isIntZero(const OBInt *a);
  * @retval 0 The argument is positive
  * @retval non-zero The argument is negative
  */
-uint8_t isIntNegative(const OBInt *a);
+uint8_t OBIntIsNegative(const OBInt *a);
 
 /**
  * @brief Creates a new OBInt containing the sum of two OBInt values
@@ -98,7 +98,7 @@ uint8_t isIntNegative(const OBInt *a);
  *
  * @return An instance of OBInt with value given by a+b
  */
-OBInt * addInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntAdd(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new OBInt containing the sum of an OBInt and a machine
@@ -109,17 +109,17 @@ OBInt * addInts(const OBInt *a, const OBInt *b);
  *
  * @return An instance of OBInt with value given by a+b
  */
-OBInt * addIntAndPrim(const OBInt *a, int64_t b);
+OBInt * OBIntAddPrimitive(const OBInt *a, int64_t b);
 
 /**
  * @brief Creates a new OBInt containing the difference of two OBInt values
  *
- * @param a A non-NULL pointer to type OBInt
- * @param b A non-NULL pointer to type OBInt
+ * @param a A non-NULL pointer to type OBInt, the minuend
+ * @param b A non-NULL pointer to type OBInt, the subtrahend
  *
  * @return An instance of OBInt with value given by a-b
  */
-OBInt * subtractInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntSubtract(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new OBInt containing the difference of an OBInt and a 
@@ -130,7 +130,7 @@ OBInt * subtractInts(const OBInt *a, const OBInt *b);
  *
  * @return An instance of OBInt with value given by a-b
  */
-OBInt * subtractIntWithPrim(const OBInt *a, int64_t b);
+OBInt * OBIntSubtractPrimitive(const OBInt *a, int64_t b);
 
 /**
  * @brief Creates a new OBInt containing the product of two OBInt values
@@ -140,7 +140,7 @@ OBInt * subtractIntWithPrim(const OBInt *a, int64_t b);
  *
  * @return An instance of OBInt with value given by a*b
  */
-OBInt * multiplyInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntMultiply(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new OBInt containing the product of an OBInt and a 
@@ -151,18 +151,18 @@ OBInt * multiplyInts(const OBInt *a, const OBInt *b);
  *
  * @return An instance of OBInt with value given by a*b
  */
-OBInt * multiplyIntAndPrim(const OBInt *a, int64_t b);
+OBInt * OBIntMultiplyPrimitive(const OBInt *a, int64_t b);
 
 /**
  * @brief Creates a new OBInt containing the quotient resule of integer division
  * between two OBInt values,
  *
- * @param a A non-NULL pointer to type OBInt
- * @param b A non-NULL pointer to type OBInt
+ * @param a A non-NULL pointer to type OBInt, the dividend
+ * @param b A non-NULL pointer to type OBInt, the divisor
  *
  * @return An instance of OBInt with value given by a/b
  */
-OBInt * divideInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntDivide(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new OBInt containing the quotient of an OBInt and a 
@@ -173,7 +173,7 @@ OBInt * divideInts(const OBInt *a, const OBInt *b);
  *
  * @return An instance of OBInt with value given by a/b
  */
-OBInt * divideIntWithPrim(const OBInt *a, int64_t b);
+OBInt * OBIntDividePrimitive(const OBInt *a, int64_t b);
 
 /**
  * @brief Creates a new OBInt containing the remainder of integer division
@@ -184,7 +184,7 @@ OBInt * divideIntWithPrim(const OBInt *a, int64_t b);
  *
  * @return An instance of OBInt with value given by a%b
  */
-OBInt * modInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntMod(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new OBInt containing the remainder of integer division
@@ -195,7 +195,7 @@ OBInt * modInts(const OBInt *a, const OBInt *b);
  *
  * @return An instance of OBInt with value given by a%b
  */
-OBInt * modIntWithPrim(const OBInt *a, int64_t b);
+OBInt * OBIntModPrimitive(const OBInt *a, int64_t b);
 
 #endif
 

--- a/include/OBMap.h
+++ b/include/OBMap.h
@@ -47,7 +47,7 @@ OBMap * copyMap(const OBMap *to_copy);
  * @details If the key is already contained within the m then the old value
  * stored at that key is replaced with the new value
  */
-void addToMap(OBMap *m, obj *key, obj *value);
+void addToMap(OBMap *m, OBObjType *key, OBObjType *value);
 
 /**
  * @brief Lookup the value stored at key in an OBMap
@@ -58,7 +58,7 @@ void addToMap(OBMap *m, obj *key, obj *value);
  * @retval NULL Key not found in OBMap instance or key bound to NULL value
  * @retval non-NULL Value found at key in OBMap
  */
-obj * lookupMapKey(const OBMap *m, const obj *key);
+OBObjType * lookupMapKey(const OBMap *m, const OBObjType *key);
 
 /**
  * @brief Removes a key-value pair from an OBMap
@@ -71,7 +71,7 @@ obj * lookupMapKey(const OBMap *m, const obj *key);
  * @warning This function runs in O(n), and is inherently more expensive
  * than an add or lookup.
  */
-void removeMapKey(OBMap *m, obj *key);
+void removeMapKey(OBMap *m, OBObjType *key);
 
 /**
  * @brief Rehashes all elements contained in an OBMap

--- a/include/OBMap.h
+++ b/include/OBMap.h
@@ -1,7 +1,7 @@
 /**
  * @file OBMap.h
  * @brief OBMap Public Interface
- * @author theck
+ * @author theck, danhd123
  */
 
 #ifndef OBMAP_H
@@ -20,14 +20,14 @@ typedef struct OBMap_struct OBMap;
  * capacity
  * @return Pointer to the newly created OBMap instance
  */
-OBMap * createMap(void);
+OBMap * OBMapCreate(void);
 
 /**
  * @brief Constructor, creates a new, empty OBMap instance with capacity given
  * @param capacity Capacity required for OBMap instance
  * @return Pointer to the newly created OBMap instance
  */
-OBMap *createMapWithCapacity(uint32_t capacity);
+OBMap *OBMapCreateWithCapacity(uint32_t capacity);
 
 /**
  * @brief Copy constructor, creates a new OBMap with the exact same contents
@@ -35,7 +35,7 @@ OBMap *createMapWithCapacity(uint32_t capacity);
  * @param to_copy Pointer to an instance of OBMap to copy
  * @return A copy of the provided OBMap
  */
-OBMap * copyMap(const OBMap *to_copy);
+OBMap * OBMapCopy(const OBMap *to_copy);
 
 /**
  * @brief Add a key-value pair to an OBMap
@@ -47,7 +47,7 @@ OBMap * copyMap(const OBMap *to_copy);
  * @details If the key is already contained within the m then the old value
  * stored at that key is replaced with the new value
  */
-void addToMap(OBMap *m, OBObjType *key, OBObjType *value);
+void OBMapAdd(OBMap *m, OBTypeRef key, OBTypeRef value);
 
 /**
  * @brief Lookup the value stored at key in an OBMap
@@ -58,7 +58,7 @@ void addToMap(OBMap *m, OBObjType *key, OBObjType *value);
  * @retval NULL Key not found in OBMap instance or key bound to NULL value
  * @retval non-NULL Value found at key in OBMap
  */
-OBObjType * lookupMapKey(const OBMap *m, const OBObjType *key);
+OBTypeRef OBMapGetValueForKey(const OBMap *m, OBTypeRef key);
 
 /**
  * @brief Removes a key-value pair from an OBMap
@@ -71,7 +71,7 @@ OBObjType * lookupMapKey(const OBMap *m, const OBObjType *key);
  * @warning This function runs in O(n), and is inherently more expensive
  * than an add or lookup.
  */
-void removeMapKey(OBMap *m, OBObjType *key);
+void OBMapRemoveKey(OBMap *m, OBTypeRef key);
 
 /**
  * @brief Rehashes all elements contained in an OBMap
@@ -81,7 +81,7 @@ void removeMapKey(OBMap *m, OBObjType *key);
  * @details This method is useful for ensuring that mutable keys will still lead
  * to valid lookups of the associated values even after key(s) have been altered
  */
-void rehashMap(OBMap *m);
+void OBMapRehash(OBMap *m);
 
 /**
  * @brief Clears an OBMap of all key-value pairs, essentially restoring it
@@ -89,7 +89,7 @@ void rehashMap(OBMap *m);
  *
  * @param m Pointer to an instance of OBMap
  */
-void clearMap(OBMap *m);
+void OBMapClear(OBMap *m);
 
 #endif
 

--- a/include/OBString.h
+++ b/include/OBString.h
@@ -1,7 +1,7 @@
 /**
  * @file OBString.h
  * @brief OBString Public Interface
- * @author theck
+ * @author theck, danhd123
  */
 
 #ifndef OBSTRING_H
@@ -31,7 +31,7 @@ typedef struct OBString_struct OBString;
  * finite length, any C strings passed to the constructor should be known to
  * meet these constraints
  */
-OBString * createString(const char *str);
+OBString * OBStringCreate(const char *str);
 
 /**
  * @brief Copies a sequence of characters from an OBString to create a new
@@ -51,7 +51,7 @@ OBString * createString(const char *str);
  * bounds then any extension beyond the bounds will return only existing
  * characters in the range, an empty string if none exist
  */
-OBString * copySubstring(const OBString *s, int64_t start, size_t length);
+OBString * OBStringGetSubstringCopyRange(const OBString *s, int64_t start, size_t length);
 
 /**
  * @brief Gets the length of an OBString
@@ -60,7 +60,7 @@ OBString * copySubstring(const OBString *s, int64_t start, size_t length);
  *
  * @return Integer length of the OBString instance
  */
-size_t stringLength(const OBString *s);
+size_t OBStringGetLength(const OBString *s);
 
 /**
  * @brief returns the character at the specified index
@@ -72,8 +72,11 @@ size_t stringLength(const OBString *s);
  *
  * @return The character at the index within the string, '\0' if the character
  * is out of bounds
+ * @discussion Unlike CFStringGetCharacterAtIndex, OBStringGetCharAtIndex 
+ * does in fact return a char, not an abstract "character" (implemented as unichar
+ * so I'm okay with leaving this API as "Char"
  */
-char charAtStringIndex(const OBString *s, int64_t i);
+char OBStringGetCharAtIndex(const OBString *s, int64_t i);
 
 /**
  * @brief concatenates the two OBString instances into a new instance of
@@ -85,7 +88,7 @@ char charAtStringIndex(const OBString *s, int64_t i);
  * @return A pointer to an new instance of OBString that contains string 
  * s1+s2
  */
-OBString * concatenateStrings(const OBString *s1, const OBString *s2);
+OBString * OBStringConcatenate(const OBString *s1, const OBString *s2);
 
 /**
  * @brief Gets the C string representation of an OBString instance
@@ -98,7 +101,7 @@ OBString * concatenateStrings(const OBString *s1, const OBString *s2);
  * @warning The returned pointer is directed at an internal C string that should
  * not be altered, a new OBString should be created if an alteration is desired
  */
-const char * getCString(const OBString *s);
+const char * OBStringGetCString(const OBString *s);
 
 /**
  * @brief Tokenizes an OBString over a character sequence
@@ -117,7 +120,7 @@ const char * getCString(const OBString *s);
  * @warning Function does not attempt to verify that delim is in fact NUL
  * terminated
  */
-OBVector * splitString(const OBString *s, const char *delim);
+OBVector * OBStringComponentsSeparatedBy(const OBString *s, const char *delim);
 
 /**
  * @brief Searches for an substring in an OBString
@@ -132,7 +135,7 @@ OBVector * splitString(const OBString *s, const char *delim);
  * @warning Function does not attempt to verify that delim is in fact NUL
  * terminated
  */
-uint8_t findSubstring(const OBString *s, const char *to_find);
+uint8_t OBStringContains(const OBString *s, const char *to_find);
 
 /**
  * @brief Finds the pattern matching an expression in an OBString
@@ -149,7 +152,7 @@ uint8_t findSubstring(const OBString *s, const char *to_find);
  * @warning Function does not attempt to verify that delim is in fact NUL
  * terminated
  */
-OBString * matchStringRegex(const OBString *s, const char *regex);
+OBString * OBStringMatchRegex(const OBString *s, const char *regex);
 
 #endif
 

--- a/include/OBString.h
+++ b/include/OBString.h
@@ -51,7 +51,7 @@ OBString * createString(const char *str);
  * bounds then any extension beyond the bounds will return only existing
  * characters in the range, an empty string if none exist
  */
-OBString * copySubstring(const OBString *s, int64_t start, uint32_t length);
+OBString * copySubstring(const OBString *s, int64_t start, size_t length);
 
 /**
  * @brief Gets the length of an OBString
@@ -60,7 +60,7 @@ OBString * copySubstring(const OBString *s, int64_t start, uint32_t length);
  *
  * @return Integer length of the OBString instance
  */
-uint32_t stringLength(const OBString *s);
+size_t stringLength(const OBString *s);
 
 /**
  * @brief returns the character at the specified index

--- a/include/OBTest.h
+++ b/include/OBTest.h
@@ -18,14 +18,14 @@ typedef struct OBTest_struct OBTest;
  * @param id Integer id for the created OBTest
  * @return Instance of OBTest with id as given by parameter
  */
-OBTest * createTest(uint32_t id);
+OBTest * OBTestCreate(uint32_t id);
 
 /**
  * @brief Returns the id of an OBTest instance
  * @param a Pointer to an instance of OBTest
  * @return id value of the OBTest argument
  */
-uint32_t getTestID(OBTest *a);
+uint32_t OBTestGetID(OBTest *a);
 
 #endif
 

--- a/include/OBVector.h
+++ b/include/OBVector.h
@@ -23,7 +23,7 @@ typedef struct OBVector_struct OBVector;
  *
  * @return Pointer to the newly created vector
  */
-OBVector * createVector(uint32_t initial_capacity);
+OBVector * OBVectorCreateWithCapacity(uint32_t initial_capacity);
 
 /**
  * @brief Copy Constructor, creates a new OBVector that is a copy of an instance
@@ -35,7 +35,7 @@ OBVector * createVector(uint32_t initial_capacity);
  * @param to_copy The OBVector instance to be copied
  * @return A new instance of OBVector that is a shallow copy of to_copy
  */
-OBVector * copyVector(const OBVector *to_copy); 
+OBVector * OBVectorCopy(const OBVector *to_copy); 
 
 /**
  * @brief Number of elements encompassed within the OBVector
@@ -45,7 +45,7 @@ OBVector * copyVector(const OBVector *to_copy);
  * @return An integer corresponding to the length required to span all elements
  * contained within the vector (including all NULL elements added by the user)
  */
-uint32_t vectorLength(const OBVector *v);
+uint32_t OBVectorGetLength(const OBVector *v);
 
 /**
  * @brief Stores the obj at the associated index in a vector, overwriting 
@@ -65,7 +65,7 @@ uint32_t vectorLength(const OBVector *v);
  * @warning Positive indexing can occur past vector length, negative indexing
  * is limited to the range [-1, -(length of v)]
  */
-void storeAtVectorIndex(OBVector *v, OBObjType *to_add, int64_t index);
+void OBVectorStoreAtIndex(OBVector *v, OBTypeRef, int64_t index);
 
 /**
  * @brief Accesses the Offbrand compatile class instance stored an index in an
@@ -85,7 +85,7 @@ void storeAtVectorIndex(OBVector *v, OBObjType *to_add, int64_t index);
  * @warning Positive indexing can occur past vector length, negative indexing
  * is limited to the range [-1, -(length of v)]
  */
-OBObjType * objAtVectorIndex(const OBVector *v, int64_t index);
+OBTypeRef OBVectorObjectAtIndex(const OBVector *v, int64_t index);
 
 /**
  * @brief Adds the contents of on vector to the end of another, concatenating
@@ -96,7 +96,7 @@ OBObjType * objAtVectorIndex(const OBVector *v, int64_t index);
  * @param to_append OBVector whos contents will be added to the end of 
  * destination
  */
-void catVectors(OBVector *destination, OBVector *to_append);
+void OBVectorConcatenateVector(OBVector *destination, OBVector *to_append);
 
 /**
  * @brief Searches for an instance of any Offbrand compatible class in an
@@ -112,7 +112,7 @@ void catVectors(OBVector *destination, OBVector *to_append);
  * known to contain instances of may different classes else the function will
  * likely cause the program to be aborted
  */
-uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find);
+uint8_t OBVectorContains(const OBVector *v, const OBTypeRef to_find);
 
 /**
  * @brief Sorts an OBVector from least-to-greatest or greatest-to-least using
@@ -128,7 +128,7 @@ uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find);
  * @warning Sorting may appear to shrink vector as NULL values interspersed with
  * valid objects will be consolidated and removed
  */
-void sortVector(OBVector *v, int8_t order);
+void OBVectorSort(OBVector *v, int8_t order);
 
 /**
  * @brief Sorts an OBVector from least-to-greatest or greatest-to-least using a
@@ -143,13 +143,13 @@ void sortVector(OBVector *v, int8_t order);
  * @warning Sorting may appear to shrink vector as NULL values interspersed with
  * valid objects will be consolidated and removed
  */
-void sortVectorWithFunct(OBVector *v, int8_t order, obcompare_fptr funct);
+void OBVectorSortWithFunction(OBVector *v, int8_t order, obcompare_fptr funct);
 
 /**
  * @brief Removes all objects from an OBVector, leaving it empty
  * @param v A pointer to an instance of OBVector
  */
-void clearVector(OBVector *v);
+void OBVectorClear(OBVector *v);
 
 #endif
 

--- a/include/OBVector.h
+++ b/include/OBVector.h
@@ -143,7 +143,7 @@ void sortVector(OBVector *v, int8_t order);
  * @warning Sorting may appear to shrink vector as NULL values interspersed with
  * valid objects will be consolidated and removed
  */
-void sortVectorWithFunct(OBVector *v, int8_t order, compare_fptr funct);
+void sortVectorWithFunct(OBVector *v, int8_t order, obcompare_fptr funct);
 
 /**
  * @brief Removes all objects from an OBVector, leaving it empty

--- a/include/OBVector.h
+++ b/include/OBVector.h
@@ -65,7 +65,7 @@ uint32_t vectorLength(const OBVector *v);
  * @warning Positive indexing can occur past vector length, negative indexing
  * is limited to the range [-1, -(length of v)]
  */
-void storeAtVectorIndex(OBVector *v, obj *to_add, int64_t index);
+void storeAtVectorIndex(OBVector *v, OBObjType *to_add, int64_t index);
 
 /**
  * @brief Accesses the Offbrand compatile class instance stored an index in an
@@ -85,7 +85,7 @@ void storeAtVectorIndex(OBVector *v, obj *to_add, int64_t index);
  * @warning Positive indexing can occur past vector length, negative indexing
  * is limited to the range [-1, -(length of v)]
  */
-obj * objAtVectorIndex(const OBVector *v, int64_t index);
+OBObjType * objAtVectorIndex(const OBVector *v, int64_t index);
 
 /**
  * @brief Adds the contents of on vector to the end of another, concatenating
@@ -112,7 +112,7 @@ void catVectors(OBVector *destination, OBVector *to_append);
  * known to contain instances of may different classes else the function will
  * likely cause the program to be aborted
  */
-uint8_t findObjInVector(const OBVector *v, const obj *to_find);
+uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find);
 
 /**
  * @brief Sorts an OBVector from least-to-greatest or greatest-to-least using

--- a/include/offbrand.h
+++ b/include/offbrand.h
@@ -7,7 +7,7 @@
  * required for memory management via reference count, class membership tests,
  * hashing, and others.
  *
- * @author theck
+ * @author theck, danhd123
  */
 
 #ifndef OFFBRAND_LIB
@@ -40,7 +40,7 @@
  * function pointers, and form the basis for all generic container classes
  * and functions.
  */
-typedef struct obj_struct * obj;
+typedef struct OBObjStruct * obj;
 
 /** 
  * reference count, tracks references to instances of Offbrand compatible

--- a/include/offbrand.h
+++ b/include/offbrand.h
@@ -40,7 +40,7 @@
  * function pointers, and form the basis for all generic container classes
  * and functions.
  */
-typedef struct OBObjStruct * obj;
+typedef struct OBObjStruct * OBObjType;
 
 /** 
  * reference count, tracks references to instances of Offbrand compatible
@@ -49,23 +49,23 @@ typedef struct OBObjStruct * obj;
 typedef uint32_t ref_count_t;
 
 /** function pointer to a deallocator for any OffBrand compatible class */
-typedef void (*dealloc_fptr)(obj *);
+typedef void (*dealloc_fptr)(OBObjType *);
 
 /** hash value, used returned from hash functions */
 typedef size_t obhash_t;
 
 /** function pointer to a hash function for any offbrand compatible class */
-typedef obhash_t (*hash_fptr)(const obj *);
+typedef obhash_t (*hash_fptr)(const OBObjType *);
 
 /**
  * function pointer to a comparision function that takes pointers to any two
  * Offbrand compatible classes and returns one of the comparision constants
  * listed in the constants section.
  */
-typedef int8_t (*compare_fptr)(const obj *, const obj *);
+typedef int8_t (*compare_fptr)(const OBObjType *, const OBObjType *);
 
 /** function pointer to a display function for any offbrand compatible class */
-typedef void (*display_fptr)(const obj *);
+typedef void (*display_fptr)(const OBObjType *);
 
 
 /* OFFBRAND STANDARD LIB */
@@ -86,7 +86,7 @@ typedef void (*display_fptr)(const obj *);
  * instances class
  * @param classname C string containing instances classname.
  */
-void initBase(obj *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
+void initBase(OBObjType *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
               compare_fptr compare_funct, display_fptr display_funct,
               const char *classname);
 
@@ -100,7 +100,7 @@ void initBase(obj *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
  * @retval NULL Reference count was decremented to 0 and deallocator was called
  * on instance
  */
-obj * release(obj *instance);
+OBObjType * release(OBObjType *instance);
 
 /**
  * @brief Increments the instances reference count by 1, indicating that the
@@ -108,7 +108,7 @@ obj * release(obj *instance);
  *
  * @param instance An instance of any Offbrand compatible class
  */
-void retain(obj *instance);
+void retain(OBObjType *instance);
 
 /**
  * @brief Returns the current reference count of the given instance.
@@ -116,7 +116,7 @@ void retain(obj *instance);
  * @param instance An instance of any Offbrand compatible class
  * @return An unsigned integer reference count
  */
-uint32_t referenceCount(obj *instance);
+uint32_t referenceCount(OBObjType *instance);
 
 /**
  * @brief Checks that the given obj is of the provided class
@@ -127,7 +127,7 @@ uint32_t referenceCount(obj *instance);
  * @retval 0 a is not an instance of classname
  * @retval non-zero a is an instance of classname
  */
-uint8_t objIsOfClass(const obj *a, const char *classname);
+uint8_t objIsOfClass(const OBObjType *a, const char *classname);
 
 /**
  * @brief Checks that two objs are of the same class
@@ -138,7 +138,7 @@ uint8_t objIsOfClass(const obj *a, const char *classname);
  * @retval 0 a and b are not of the same class
  * @retval non-zero a and b are of the same class
  */
-uint8_t sameClass(const obj *a, const obj *b);
+uint8_t sameClass(const OBObjType *a, const OBObjType *b);
 
 /**
  * @brief Computes the hash value of the instance using a class specific hash
@@ -147,7 +147,7 @@ uint8_t sameClass(const obj *a, const obj *b);
  * @param to_hash An instance of any Offbrand compatible class
  * @return Hash value
  */
-obhash_t hash(const obj *to_hash);
+obhash_t hash(const OBObjType *to_hash);
 
 /**
  * @brief comparision operator between any two Offbrand compatible classes
@@ -161,7 +161,7 @@ obhash_t hash(const obj *to_hash);
  * @retval OB_NOT_EQUAL obj a is not equal to b, but no other relationship can
  * be infered
  */
-int8_t compare(const obj *a, const obj *b);
+int8_t compare(const OBObjType *a, const OBObjType *b);
 
 /**
  * @brief display operation prints information about the instance of any
@@ -169,7 +169,7 @@ int8_t compare(const obj *a, const obj *b);
  *
  * @param to_print An instance of any Offbrand compativle class
  */
-void display(const obj *to_print);
+void display(const OBObjType *to_print);
 
 #endif
 

--- a/include/offbrand.h
+++ b/include/offbrand.h
@@ -178,5 +178,10 @@ int8_t OBCompare(OBTypeRef a, OBTypeRef b);
  */
 void OBDisplay(OBTypeRef to_print);
 
+/* TODO: consider replacing OBDisplayWith OBDescription - something that returns an
+ * OBString or const char * that you can do with what you like instead of being
+ * limited to printing to stderr
+ */
+
 #endif
 

--- a/include/offbrand.h
+++ b/include/offbrand.h
@@ -41,31 +41,32 @@
  * and functions.
  */
 typedef struct OBObjStruct * OBObjType;
+typedef const void * OBTypeRef;
 
 /** 
  * reference count, tracks references to instances of Offbrand compatible
  * classes 
  */
-typedef uint32_t ref_count_t;
+typedef uint32_t obref_count_t;
 
 /** function pointer to a deallocator for any OffBrand compatible class */
-typedef void (*dealloc_fptr)(OBObjType *);
+typedef void (*obdealloc_fptr)(OBObjType *);
 
 /** hash value, used returned from hash functions */
 typedef size_t obhash_t;
 
 /** function pointer to a hash function for any offbrand compatible class */
-typedef obhash_t (*hash_fptr)(const OBObjType *);
+typedef obhash_t (*obhash_fptr)(const OBObjType *);
 
 /**
  * function pointer to a comparision function that takes pointers to any two
  * Offbrand compatible classes and returns one of the comparision constants
  * listed in the constants section.
  */
-typedef int8_t (*compare_fptr)(const OBObjType *, const OBObjType *);
+typedef int8_t (*obcompare_fptr)(const OBObjType *, const OBObjType *);
 
 /** function pointer to a display function for any offbrand compatible class */
-typedef void (*display_fptr)(const OBObjType *);
+typedef void (*obdisplay_fptr)(const OBObjType *);
 
 
 /* OFFBRAND STANDARD LIB */
@@ -86,8 +87,8 @@ typedef void (*display_fptr)(const OBObjType *);
  * instances class
  * @param classname C string containing instances classname.
  */
-void initBase(OBObjType *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
-              compare_fptr compare_funct, display_fptr display_funct,
+void OBInitBase(OBTypeRef instance, obdealloc_fptr dealloc_funct, obhash_fptr hash_funct,
+              obcompare_fptr compare_funct, obdisplay_fptr display_funct,
               const char *classname);
 
 /**
@@ -99,8 +100,14 @@ void initBase(OBObjType *instance, dealloc_fptr dealloc_funct, hash_fptr hash_fu
  * referenced
  * @retval NULL Reference count was decremented to 0 and deallocator was called
  * on instance
+ * @discussion Unlike certain other frameworks (CoreFoundation, Foundation),
+ * release returns the object or NULL, and retain does not. This leads to some
+ * possible safety improvements if applied well (e.g. obj = OBRelease(obj);)
+ * however if not used correctly will mask leaks when the assignment to obj is
+ * removed for performance reasons. Mixed use of as-void and as-OBTypeRef of
+ * this function is highly discouraged.
  */
-OBObjType * release(OBObjType *instance);
+OBTypeRef OBRelease(OBTypeRef instance);
 
 /**
  * @brief Increments the instances reference count by 1, indicating that the
@@ -108,7 +115,7 @@ OBObjType * release(OBObjType *instance);
  *
  * @param instance An instance of any Offbrand compatible class
  */
-void retain(OBObjType *instance);
+OBTypeRef OBRetain(OBTypeRef instance);
 
 /**
  * @brief Returns the current reference count of the given instance.
@@ -116,7 +123,7 @@ void retain(OBObjType *instance);
  * @param instance An instance of any Offbrand compatible class
  * @return An unsigned integer reference count
  */
-uint32_t referenceCount(OBObjType *instance);
+obref_count_t OBReferenceCount(OBObjType *instance);
 
 /**
  * @brief Checks that the given obj is of the provided class

--- a/include/offbrand.h
+++ b/include/offbrand.h
@@ -50,23 +50,23 @@ typedef const void * OBTypeRef;
 typedef uint32_t obref_count_t;
 
 /** function pointer to a deallocator for any OffBrand compatible class */
-typedef void (*obdealloc_fptr)(OBObjType *);
+typedef void (*obdealloc_fptr)(OBTypeRef);
 
 /** hash value, used returned from hash functions */
 typedef size_t obhash_t;
 
 /** function pointer to a hash function for any offbrand compatible class */
-typedef obhash_t (*obhash_fptr)(const OBObjType *);
+typedef obhash_t (*obhash_fptr)(OBTypeRef);
 
 /**
  * function pointer to a comparision function that takes pointers to any two
  * Offbrand compatible classes and returns one of the comparision constants
  * listed in the constants section.
  */
-typedef int8_t (*obcompare_fptr)(const OBObjType *, const OBObjType *);
+typedef int8_t (*obcompare_fptr)(OBTypeRef, OBTypeRef);
 
 /** function pointer to a display function for any offbrand compatible class */
-typedef void (*obdisplay_fptr)(const OBObjType *);
+typedef void (*obdisplay_fptr)(OBTypeRef);
 
 
 /* OFFBRAND STANDARD LIB */
@@ -134,7 +134,7 @@ obref_count_t OBReferenceCount(OBObjType *instance);
  * @retval 0 a is not an instance of classname
  * @retval non-zero a is an instance of classname
  */
-uint8_t objIsOfClass(const OBObjType *a, const char *classname);
+uint8_t OBObjIsOfClass(OBTypeRef a, const char *classname);
 
 /**
  * @brief Checks that two objs are of the same class
@@ -145,7 +145,7 @@ uint8_t objIsOfClass(const OBObjType *a, const char *classname);
  * @retval 0 a and b are not of the same class
  * @retval non-zero a and b are of the same class
  */
-uint8_t sameClass(const OBObjType *a, const OBObjType *b);
+uint8_t OBObjectsHaveSameClass(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Computes the hash value of the instance using a class specific hash
@@ -154,7 +154,7 @@ uint8_t sameClass(const OBObjType *a, const OBObjType *b);
  * @param to_hash An instance of any Offbrand compatible class
  * @return Hash value
  */
-obhash_t hash(const OBObjType *to_hash);
+obhash_t OBHash(OBTypeRef to_hash);
 
 /**
  * @brief comparision operator between any two Offbrand compatible classes
@@ -168,7 +168,7 @@ obhash_t hash(const OBObjType *to_hash);
  * @retval OB_NOT_EQUAL obj a is not equal to b, but no other relationship can
  * be infered
  */
-int8_t compare(const OBObjType *a, const OBObjType *b);
+int8_t OBCompare(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief display operation prints information about the instance of any
@@ -176,7 +176,7 @@ int8_t compare(const OBObjType *a, const OBObjType *b);
  *
  * @param to_print An instance of any Offbrand compativle class
  */
-void display(const OBObjType *to_print);
+void OBDisplay(OBTypeRef to_print);
 
 #endif
 

--- a/include/private/OBDeque_Private.h
+++ b/include/private/OBDeque_Private.h
@@ -41,7 +41,7 @@ OBDequeNode * createDequeNode(OBObjType *to_store);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDequeNode(OBObjType *to_dealloc);
+void deallocDequeNode(OBTypeRef to_dealloc);
 
 
 /* OBDequeIterator type */
@@ -78,7 +78,7 @@ struct OBDequeIterator_struct * createDequeIterator(const OBDeque *deque,
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDequeIterator(OBObjType *to_dealloc);
+void deallocDequeIterator(OBTypeRef to_dealloc);
 
 
 /* OBDeque Type */
@@ -130,7 +130,7 @@ OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct);
  * @param to_hash An obj pointer to an instance of OBDeque
  * @return Key value (hash) for the given obj pointer to a OBDeque
  */
-obhash_t hashDeque(const OBObjType *to_hash);
+obhash_t hashDeque(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBDeque
@@ -142,14 +142,14 @@ obhash_t hashDeque(const OBObjType *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareDeques(const OBObjType *a, const OBObjType *b);
+int8_t compareDeques(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Displays information about an OBDeque to stderr
  *
  * @param to_print A non-NULL obj pointer to type OBDeque
  */
-void displayDeque(const OBObjType *to_print);
+void displayDeque(OBTypeRef to_print);
 
 /**
  * @brief Destructor for OBDeque
@@ -158,7 +158,7 @@ void displayDeque(const OBObjType *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDeque(OBObjType *to_dealloc);
+void deallocDeque(OBTypeRef to_dealloc);
 
 
 #endif

--- a/include/private/OBDeque_Private.h
+++ b/include/private/OBDeque_Private.h
@@ -17,7 +17,7 @@
  */
 typedef struct OBDequeNode_struct{
   OBObjType base; /**< obj containing reference count and class membership data */
-  OBObjType *stored; /**< obj stored within the node in the deque */
+  OBTypeRef stored; /**< obj stored within the node in the deque */
   struct OBDequeNode_struct *next; /**< Pointer to the next node in the list */
   struct OBDequeNode_struct *prev; /**< Pointer to the prev node in the list */
 } OBDequeNode;
@@ -32,7 +32,7 @@ typedef struct OBDequeNode_struct{
  * @return A new instance of OBDeque node storing to_store and with NULL
  * references to next and prev nodes
  */
-OBDequeNode * createDequeNode(OBObjType *to_store);
+OBDequeNode * OBDequeNodeCreate(OBTypeRef to_store);
 
 /**
  * @brief Destructor for OBDequeNode
@@ -41,7 +41,7 @@ OBDequeNode * createDequeNode(OBObjType *to_store);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDequeNode(OBTypeRef to_dealloc);
+void OBDequeNodeDealloc(OBTypeRef to_dealloc);
 
 
 /* OBDequeIterator type */
@@ -68,7 +68,7 @@ struct OBDequeIterator_struct{
  *
  * @return An instance of OBDequeIterator
  */
-struct OBDequeIterator_struct * createDequeIterator(const OBDeque *deque, 
+struct OBDequeIterator_struct * OBDequeIteratorCreate(const OBDeque *deque, 
                                                     OBDequeNode *node);
 
 /**
@@ -78,7 +78,7 @@ struct OBDequeIterator_struct * createDequeIterator(const OBDeque *deque,
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDequeIterator(OBTypeRef to_dealloc);
+void OBDequeIteratorDealloc(OBTypeRef to_dealloc);
 
 
 /* OBDeque Type */
@@ -106,7 +106,7 @@ struct OBDeque_struct{
  * @warning All public constructors should call this constructor and initialize
  * individual members as needed, so that all base data is initialized properly
  */
-OBDeque * createDefaultDeque(void);
+OBDeque * OBDequeCreateDefault(void);
 
 /**
  * @brief Internal merge sort implementation for an OBDeque
@@ -123,14 +123,14 @@ OBDeque * createDefaultDeque(void);
  * sorting should use the publicly accessable function which calls this method
  * internally.
  */
-OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct);
+OBDeque OBDequeSortRecursive(OBDeque deque, int8_t order, obcompare_fptr funct);
 
 /**
  * @brief Hash function for OBDeque
  * @param to_hash An obj pointer to an instance of OBDeque
  * @return Key value (hash) for the given obj pointer to a OBDeque
  */
-obhash_t hashDeque(OBTypeRef to_hash);
+obhash_t OBDequeHash(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBDeque
@@ -142,14 +142,14 @@ obhash_t hashDeque(OBTypeRef to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareDeques(OBTypeRef a, OBTypeRef b);
+int8_t OBDequeCompare(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Displays information about an OBDeque to stderr
  *
  * @param to_print A non-NULL obj pointer to type OBDeque
  */
-void displayDeque(OBTypeRef to_print);
+void OBDequeDisplay(OBTypeRef to_print);
 
 /**
  * @brief Destructor for OBDeque
@@ -158,7 +158,7 @@ void displayDeque(OBTypeRef to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDeque(OBTypeRef to_dealloc);
+void OBDequeDealloc(OBTypeRef to_dealloc);
 
 
 #endif

--- a/include/private/OBDeque_Private.h
+++ b/include/private/OBDeque_Private.h
@@ -16,8 +16,8 @@
  * node within a doubly linked list. Internally referenced only
  */
 typedef struct OBDequeNode_struct{
-  obj base; /**< obj containing reference count and class membership data */
-  obj *stored; /**< obj stored within the node in the deque */
+  OBObjType base; /**< obj containing reference count and class membership data */
+  OBObjType *stored; /**< obj stored within the node in the deque */
   struct OBDequeNode_struct *next; /**< Pointer to the next node in the list */
   struct OBDequeNode_struct *prev; /**< Pointer to the prev node in the list */
 } OBDequeNode;
@@ -32,7 +32,7 @@ typedef struct OBDequeNode_struct{
  * @return A new instance of OBDeque node storing to_store and with NULL
  * references to next and prev nodes
  */
-OBDequeNode * createDequeNode(obj *to_store);
+OBDequeNode * createDequeNode(OBObjType *to_store);
 
 /**
  * @brief Destructor for OBDequeNode
@@ -41,7 +41,7 @@ OBDequeNode * createDequeNode(obj *to_store);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDequeNode(obj *to_dealloc);
+void deallocDequeNode(OBObjType *to_dealloc);
 
 
 /* OBDequeIterator type */
@@ -51,7 +51,7 @@ void deallocDequeNode(obj *to_dealloc);
  * for an iterator of a doubly linked list.
  */
 struct OBDequeIterator_struct{
-  obj base; /**< obj containing reference count and class membership data */
+  OBObjType base; /**< obj containing reference count and class membership data */
   const OBDeque *deque; /**< OBDeque that the iterator is bound to */
   OBDequeNode *node; /**< The OBDequeNode that the iterator references within
                        deque */
@@ -78,7 +78,7 @@ struct OBDequeIterator_struct * createDequeIterator(const OBDeque *deque,
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDequeIterator(obj *to_dealloc);
+void deallocDequeIterator(OBObjType *to_dealloc);
 
 
 /* OBDeque Type */
@@ -88,7 +88,7 @@ void deallocDequeIterator(obj *to_dealloc);
  * doubly linked list
  */
 struct OBDeque_struct{
-  obj base; /**< obj containing reference count and class membership data */
+  OBObjType base; /**< obj containing reference count and class membership data */
   OBDequeNode *head; /**< pointer to the OBDequeNode at the head of the deque */
   OBDequeNode *tail; /**< pointer to the OBDequeNode at the tail of the deque */
   uint64_t length; /**< integer length of the deque (or number of elements
@@ -130,7 +130,7 @@ OBDeque recursiveSort(OBDeque deque, int8_t order, compare_fptr funct);
  * @param to_hash An obj pointer to an instance of OBDeque
  * @return Key value (hash) for the given obj pointer to a OBDeque
  */
-obhash_t hashDeque(const obj *to_hash);
+obhash_t hashDeque(const OBObjType *to_hash);
 
 /**
  * @brief Compares two instances of OBDeque
@@ -142,14 +142,14 @@ obhash_t hashDeque(const obj *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareDeques(const obj *a, const obj *b);
+int8_t compareDeques(const OBObjType *a, const OBObjType *b);
 
 /**
  * @brief Displays information about an OBDeque to stderr
  *
  * @param to_print A non-NULL obj pointer to type OBDeque
  */
-void displayDeque(const obj *to_print);
+void displayDeque(const OBObjType *to_print);
 
 /**
  * @brief Destructor for OBDeque
@@ -158,7 +158,7 @@ void displayDeque(const obj *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocDeque(obj *to_dealloc);
+void deallocDeque(OBObjType *to_dealloc);
 
 
 #endif

--- a/include/private/OBDeque_Private.h
+++ b/include/private/OBDeque_Private.h
@@ -123,7 +123,7 @@ OBDeque * createDefaultDeque(void);
  * sorting should use the publicly accessable function which calls this method
  * internally.
  */
-OBDeque recursiveSort(OBDeque deque, int8_t order, compare_fptr funct);
+OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct);
 
 /**
  * @brief Hash function for OBDeque

--- a/include/private/OBInt_Private.h
+++ b/include/private/OBInt_Private.h
@@ -40,7 +40,7 @@ OBInt * createDefaultInt(uint64_t num_digits);
  * @param to_hash An obj pointer to an instance of OBInt
  * @return Key value (hash) for the given obj pointer to a OBInt
  */
-obhash_t hashInt(const OBObjType *to_hash);
+obhash_t hashInt(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBInt
@@ -52,7 +52,7 @@ obhash_t hashInt(const OBObjType *to_hash);
  * @retval OB_GREATER_THAN obj a is greater than b
  * @retval OB_EQUAL_TO obj a is equal to b
  */
-int8_t compareInts(const OBObjType *a, const OBObjType *b);
+int8_t compareInts(OBTypeRef a, OBTypeRef b);
 /* Arguments are obj * so that a function pointer can be used for container
  * class sorting/search */
 
@@ -74,7 +74,7 @@ int8_t compareMagnitudes(const OBInt *a, const OBInt *b);
  * @param to_print A non-NULL obj pointer to an instance of type
  * OBInt
  */
-void displayInt(const OBObjType *to_print);
+void displayInt(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBInt
@@ -83,7 +83,7 @@ void displayInt(const OBObjType *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocInt(OBObjType *to_dealloc);
+void deallocInt(OBTypeRef to_dealloc);
 
 /**
  * @brief Creates a new integer as a result of addition between two OBInts

--- a/include/private/OBInt_Private.h
+++ b/include/private/OBInt_Private.h
@@ -16,7 +16,7 @@
  * an instance of OBInt
  */
 struct OBInt_struct{
-  obj base; /**< obj containing reference count and class membership data */
+  OBObjType base; /**< obj containing reference count and class membership data */
   int8_t sign; /**< Sign of integer value, positive or negative */
   int8_t *digits; /**< Digit array, in little endian order */
   uint64_t num_digits; /**< Number of digits in the digit array */
@@ -40,7 +40,7 @@ OBInt * createDefaultInt(uint64_t num_digits);
  * @param to_hash An obj pointer to an instance of OBInt
  * @return Key value (hash) for the given obj pointer to a OBInt
  */
-obhash_t hashInt(const obj *to_hash);
+obhash_t hashInt(const OBObjType *to_hash);
 
 /**
  * @brief Compares two instances of OBInt
@@ -52,7 +52,7 @@ obhash_t hashInt(const obj *to_hash);
  * @retval OB_GREATER_THAN obj a is greater than b
  * @retval OB_EQUAL_TO obj a is equal to b
  */
-int8_t compareInts(const obj *a, const obj *b);
+int8_t compareInts(const OBObjType *a, const OBObjType *b);
 /* Arguments are obj * so that a function pointer can be used for container
  * class sorting/search */
 
@@ -74,7 +74,7 @@ int8_t compareMagnitudes(const OBInt *a, const OBInt *b);
  * @param to_print A non-NULL obj pointer to an instance of type
  * OBInt
  */
-void displayInt(const obj *to_print);
+void displayInt(const OBObjType *to_print);
 
 /** 
  * @brief Destructor for OBInt
@@ -83,7 +83,7 @@ void displayInt(const obj *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocInt(obj *to_dealloc);
+void deallocInt(OBObjType *to_dealloc);
 
 /**
  * @brief Creates a new integer as a result of addition between two OBInts

--- a/include/private/OBInt_Private.h
+++ b/include/private/OBInt_Private.h
@@ -33,14 +33,14 @@ struct OBInt_struct{
  * @warning All public constructors should call this constructor and intialize
  * individual members as needed, so that all base data is initialized properly.
  */
-OBInt * createDefaultInt(uint64_t num_digits);
+OBInt * OBIntCreateDefault(uint64_t num_digits);
 
 /**
  * @brief Hash function for OBInt
  * @param to_hash An obj pointer to an instance of OBInt
  * @return Key value (hash) for the given obj pointer to a OBInt
  */
-obhash_t hashInt(OBTypeRef to_hash);
+obhash_t OBIntHash(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBInt
@@ -52,7 +52,7 @@ obhash_t hashInt(OBTypeRef to_hash);
  * @retval OB_GREATER_THAN obj a is greater than b
  * @retval OB_EQUAL_TO obj a is equal to b
  */
-int8_t compareInts(OBTypeRef a, OBTypeRef b);
+int8_t OBIntCompare(OBTypeRef a, OBTypeRef b);
 /* Arguments are obj * so that a function pointer can be used for container
  * class sorting/search */
 
@@ -65,7 +65,7 @@ int8_t compareInts(OBTypeRef a, OBTypeRef b);
  * @retval OB_GREATER_THAN Magnitude of a is greater than to b
  * @retval OB_EQUAL_TO Magnitude of a is equal to b
  */
-int8_t compareMagnitudes(const OBInt *a, const OBInt *b);
+int8_t OBIntCompareMagnitudes(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Descriptor for an instance of OBInt, prints relevant
@@ -74,7 +74,7 @@ int8_t compareMagnitudes(const OBInt *a, const OBInt *b);
  * @param to_print A non-NULL obj pointer to an instance of type
  * OBInt
  */
-void displayInt(OBTypeRef to_print);
+void OBIntDisplay(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBInt
@@ -83,7 +83,7 @@ void displayInt(OBTypeRef to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocInt(OBTypeRef to_dealloc);
+void OBIntDealloc(OBTypeRef to_dealloc);
 
 /**
  * @brief Creates a new integer as a result of addition between two OBInts
@@ -94,7 +94,7 @@ void deallocInt(OBTypeRef to_dealloc);
  *
  * @return An instance of OBInt, which may or may not have proper sign
  */
-OBInt * addUnsignedInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntAddUnsigned(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new integer as a result of subtraction between two OBInts
@@ -108,7 +108,7 @@ OBInt * addUnsignedInts(const OBInt *a, const OBInt *b);
  * @warning Proper results guaranteed only for a >= b, a < b will not work and
  * probably will cause segmentation faults
  */
-OBInt * subtractUnsignedInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntSubtractUnsigned(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new integer as a result of multiplication between two OBInts
@@ -121,7 +121,7 @@ OBInt * subtractUnsignedInts(const OBInt *a, const OBInt *b);
  *
  * @details Multiplication performed using the Karatsuba multiplcation algorithm
  */
-OBInt * multiplyUnsignedInts(const OBInt *a, const OBInt *b);
+OBInt * OBIntMultiplyUnsigned(const OBInt *a, const OBInt *b);
 
 /**
  * @brief Creates a new integer as a result of divison or modulus between two 
@@ -136,7 +136,7 @@ OBInt * multiplyUnsignedInts(const OBInt *a, const OBInt *b);
  *
  * @return An instance of OBInt, which may or may not have proper sign
  */
-OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx, 
+OBInt * OBIntReduceUnsigned(const OBInt *a, const OBInt *b, const OBInt *approx, 
                            uint8_t quotient);
 
 /**
@@ -148,7 +148,7 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
  * @return An integer index where the most significant non-zero digit in a can
  * be found
  */
-uint64_t mostSig(const OBInt *a);
+uint64_t OBIntGetMostSignificantDigit(const OBInt *a);
 
 /**
  * @brief Splits the OBInt into two OBInt instances at given index.
@@ -165,7 +165,7 @@ uint64_t mostSig(const OBInt *a);
  * to a 0 OBInt and b2 is set to point to a copy of a. a is treated as unsigned
  * for this operation
  */
-void splitInt(const OBInt *a, uint64_t i, OBInt **b1, OBInt **b0);
+void OBIntSplit(const OBInt *a, uint64_t i, OBInt **b1, OBInt **b0);
 
 /**int
  * @brief Shifts the OBInt the given number of digits to the left, in place, 
@@ -174,7 +174,7 @@ void splitInt(const OBInt *a, uint64_t i, OBInt **b1, OBInt **b0);
  * @param a A non-NULL pointer to type OBInt
  * @param m Number of digits to shift
  */
-void shiftInt(OBInt *a, uint64_t m);
+void OBIntShiftDigitsLeft(OBInt *a, uint64_t m);
 
 /**
  * @brief Returns the unsigned value of the OBInt 
@@ -183,7 +183,7 @@ void shiftInt(OBInt *a, uint64_t m);
  *
  * @return a positive int64_t representing the value of the argument OBInt
  */
-int64_t unsignedValue(const OBInt *a);
+int64_t OBIntGetUnsignedValue(const OBInt *a);
 
 /**
  * @brief Sets the number of digits operated on in a primitive from 1 to 17
@@ -195,7 +195,7 @@ int64_t unsignedValue(const OBInt *a);
  * @warning The default value of 17 is most efficient, this method exists for
  * testing purposes only!
  */
-void setMaxDigits(uint8_t digits);
+void OBIntSetMaxDigits(uint8_t digits);
 
 #endif
 

--- a/include/private/OBMap_Private.h
+++ b/include/private/OBMap_Private.h
@@ -83,14 +83,14 @@ void replaceMapPairValue(OBMapPair *mp, OBObjType *value);
  *
  * @return Key value (hash) for the given obj pointer to a OBMapPair
  */
-obhash_t hashMapPair(const OBObjType *to_hash);
+obhash_t hashMapPair(OBTypeRef to_hash);
 
 /**
  * @brief Displays an instance of OBMapPair to stderr
  *
  * @param to_print A non-NULL obj pointer to type OBMapPair
  */
-void displayMapPair(const OBObjType *to_print);
+void displayMapPair(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBMapPair
@@ -101,7 +101,7 @@ void displayMapPair(const OBObjType *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocMapPair(OBObjType *to_dealloc); 
+void deallocMapPair(OBTypeRef to_dealloc);
 
 
 /* OBMap DATA */
@@ -140,7 +140,7 @@ OBMap * createDefaultMap(void);
  *
  * @return Key value (hash) for the given obj pointer to a OBMap
  */
-obhash_t hashMap(const OBObjType *to_hash);
+obhash_t hashMap(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBMap
@@ -152,7 +152,7 @@ obhash_t hashMap(const OBObjType *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareMaps(const OBObjType *a, const OBObjType *b);
+int8_t compareMaps(OBTypeRef a, OBTypeRef b);
 /* Arguments are obj * so that a function pointer can be used for container
  * class sorting/search */
 
@@ -161,7 +161,7 @@ int8_t compareMaps(const OBObjType *a, const OBObjType *b);
  *
  * @param to_print A non-NULL obj pointer to type OBMap
  */
-void displayMap(const OBObjType *to_print);
+void displayMap(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBMap
@@ -172,7 +172,7 @@ void displayMap(const OBObjType *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocMap(OBObjType *to_dealloc);
+void deallocMap(OBTypeRef to_dealloc);
 
 /**
  * @brief Increases the size of the map to the next capacity within 

--- a/include/private/OBMap_Private.h
+++ b/include/private/OBMap_Private.h
@@ -35,9 +35,9 @@ extern const double MAX_LOAD_FACTOR;
  * given map
  */
 typedef struct OBMapPair_struct{
-  obj base; /**< obj containing reference count and class membership data */
-  obj *key; /**< obj pointer to the key used to lookup within the hash */
-  obj *value; /**< obj pointer to the value stored in the hash */
+  OBObjType base; /**< obj containing reference count and class membership data */
+  OBObjType *key; /**< obj pointer to the key used to lookup within the hash */
+  OBObjType *value; /**< obj pointer to the value stored in the hash */
 } OBMapPair;
 
 /* OBMapPair PRIVATE METHODS */
@@ -55,7 +55,7 @@ typedef struct OBMapPair_struct{
  * @warning All public constructors should call this constructor and intialize
  * individual members as needed, so that all base data is initialized properly.
  */
-OBMapPair * createMapPair(obj *key, obj *value);
+OBMapPair * createMapPair(OBObjType *key, OBObjType *value);
 
 /**
  * @brief Copy constructor, creates a new OBMapPair with the same key-value of
@@ -74,7 +74,7 @@ OBMapPair * copyMapPair(OBMapPair *mp);
  * @param mp An instance of OBMapPair
  * @param value The new value to replace the existing value
  */
-void replaceMapPairValue(OBMapPair *mp, obj *value);
+void replaceMapPairValue(OBMapPair *mp, OBObjType *value);
 
 /**
  * @brief Hash function for OBMapPair
@@ -83,14 +83,14 @@ void replaceMapPairValue(OBMapPair *mp, obj *value);
  *
  * @return Key value (hash) for the given obj pointer to a OBMapPair
  */
-obhash_t hashMapPair(const obj *to_hash);
+obhash_t hashMapPair(const OBObjType *to_hash);
 
 /**
  * @brief Displays an instance of OBMapPair to stderr
  *
  * @param to_print A non-NULL obj pointer to type OBMapPair
  */
-void displayMapPair(const obj *to_print);
+void displayMapPair(const OBObjType *to_print);
 
 /** 
  * @brief Destructor for OBMapPair
@@ -101,7 +101,7 @@ void displayMapPair(const obj *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocMapPair(obj *to_dealloc); 
+void deallocMapPair(OBObjType *to_dealloc); 
 
 
 /* OBMap DATA */
@@ -111,7 +111,7 @@ void deallocMapPair(obj *to_dealloc);
  * an instance of OBMap
  */
 struct OBMap_struct{
-  obj base; /**< obj containing reference count and class membership data */
+  OBObjType base; /**< obj containing reference count and class membership data */
   uint8_t cap_idx; /**< index within MAP_CAPACITIES used as lookup for
                      capacity of map */
   OBVector *hash_table; /**< map lookup table */
@@ -140,7 +140,7 @@ OBMap * createDefaultMap(void);
  *
  * @return Key value (hash) for the given obj pointer to a OBMap
  */
-obhash_t hashMap(const obj *to_hash);
+obhash_t hashMap(const OBObjType *to_hash);
 
 /**
  * @brief Compares two instances of OBMap
@@ -152,7 +152,7 @@ obhash_t hashMap(const obj *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareMaps(const obj *a, const obj *b);
+int8_t compareMaps(const OBObjType *a, const OBObjType *b);
 /* Arguments are obj * so that a function pointer can be used for container
  * class sorting/search */
 
@@ -161,7 +161,7 @@ int8_t compareMaps(const obj *a, const obj *b);
  *
  * @param to_print A non-NULL obj pointer to type OBMap
  */
-void displayMap(const obj *to_print);
+void displayMap(const OBObjType *to_print);
 
 /** 
  * @brief Destructor for OBMap
@@ -172,7 +172,7 @@ void displayMap(const obj *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocMap(obj *to_dealloc);
+void deallocMap(OBObjType *to_dealloc);
 
 /**
  * @brief Increases the size of the map to the next capacity within 
@@ -199,7 +199,7 @@ void addToHashTable(OBMap *m, OBDequeIterator *it);
  * @return Index in the hash_table where a result can be found or where a NULL
  * value resides if key was not found
  */
-obhash_t findKeyInHashTable(const OBMap *m, const obj *key);
+obhash_t findKeyInHashTable(const OBMap *m, const OBObjType *key);
 
 /**
  * @brief Generates an offset from the hash value to rectify collisions

--- a/include/private/OBMap_Private.h
+++ b/include/private/OBMap_Private.h
@@ -36,8 +36,8 @@ extern const double MAX_LOAD_FACTOR;
  */
 typedef struct OBMapPair_struct{
   OBObjType base; /**< obj containing reference count and class membership data */
-  OBObjType *key; /**< obj pointer to the key used to lookup within the hash */
-  OBObjType *value; /**< obj pointer to the value stored in the hash */
+  OBTypeRef key; /**< obj pointer to the key used to lookup within the hash */
+  OBTypeRef value; /**< obj pointer to the value stored in the hash */
 } OBMapPair;
 
 /* OBMapPair PRIVATE METHODS */
@@ -55,7 +55,7 @@ typedef struct OBMapPair_struct{
  * @warning All public constructors should call this constructor and intialize
  * individual members as needed, so that all base data is initialized properly.
  */
-OBMapPair * createMapPair(OBObjType *key, OBObjType *value);
+OBMapPair * OBMapPairCreate(OBTypeRef key, OBTypeRef value);
 
 /**
  * @brief Copy constructor, creates a new OBMapPair with the same key-value of
@@ -66,7 +66,7 @@ OBMapPair * createMapPair(OBObjType *key, OBObjType *value);
  * @return An instance of class OBMapPair that contains the same key-value as
  * mp
  */
-OBMapPair * copyMapPair(OBMapPair *mp);
+OBMapPair * OBMapPairCopy(OBMapPair *mp);
 
 /**
  * @brief Replaces existing value in an OBMapPair with the supplied value
@@ -74,7 +74,7 @@ OBMapPair * copyMapPair(OBMapPair *mp);
  * @param mp An instance of OBMapPair
  * @param value The new value to replace the existing value
  */
-void replaceMapPairValue(OBMapPair *mp, OBObjType *value);
+void OBMapPairReplaceValue(OBMapPair *mp, OBTypeRef value);
 
 /**
  * @brief Hash function for OBMapPair
@@ -83,14 +83,14 @@ void replaceMapPairValue(OBMapPair *mp, OBObjType *value);
  *
  * @return Key value (hash) for the given obj pointer to a OBMapPair
  */
-obhash_t hashMapPair(OBTypeRef to_hash);
+obhash_t OBMapPairHash(OBTypeRef to_hash);
 
 /**
  * @brief Displays an instance of OBMapPair to stderr
  *
  * @param to_print A non-NULL obj pointer to type OBMapPair
  */
-void displayMapPair(OBTypeRef to_print);
+void OBMapPairDisplay(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBMapPair
@@ -101,7 +101,7 @@ void displayMapPair(OBTypeRef to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocMapPair(OBTypeRef to_dealloc);
+void OBMapPairDealloc(OBTypeRef to_dealloc);
 
 
 /* OBMap DATA */
@@ -131,7 +131,7 @@ struct OBMap_struct{
  * @warning All public constructors should call this constructor and intialize
  * individual members as needed, so that all base data is initialized properly.
  */
-OBMap * createDefaultMap(void);
+OBMap * OBMapCreateDefault(void);
 
 /**
  * @brief Hash function for OBMap
@@ -140,7 +140,7 @@ OBMap * createDefaultMap(void);
  *
  * @return Key value (hash) for the given obj pointer to a OBMap
  */
-obhash_t hashMap(OBTypeRef to_hash);
+obhash_t OBMapHash(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBMap
@@ -152,7 +152,7 @@ obhash_t hashMap(OBTypeRef to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareMaps(OBTypeRef a, OBTypeRef b);
+int8_t OBMapCompare(OBTypeRef a, OBTypeRef b);
 /* Arguments are obj * so that a function pointer can be used for container
  * class sorting/search */
 
@@ -161,7 +161,7 @@ int8_t compareMaps(OBTypeRef a, OBTypeRef b);
  *
  * @param to_print A non-NULL obj pointer to type OBMap
  */
-void displayMap(OBTypeRef to_print);
+void OBMapDisplay(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBMap
@@ -172,7 +172,7 @@ void displayMap(OBTypeRef to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocMap(OBTypeRef to_dealloc);
+void OBMapDealloc(OBTypeRef to_dealloc);
 
 /**
  * @brief Increases the size of the map to the next capacity within 
@@ -180,7 +180,7 @@ void deallocMap(OBTypeRef to_dealloc);
  *
  * @param to_size OBMap to resize
  */
-void increaseMapSize(OBMap *to_size);
+void OBMapIncreaseSize(OBMap *to_size);
 
 /**
  * @brief Adds an OBDequeIterator to the proper location within the OBMap
@@ -188,7 +188,7 @@ void increaseMapSize(OBMap *to_size);
  * @param m The OBMap to add the iterator to
  * @param it The OBDequeIterator to add to the hash table
  */
-void addToHashTable(OBMap *m, OBDequeIterator *it);
+void OBMapAddToHashTable(OBMap *m, OBDequeIterator *it);
 
 /**
  * @brief Finds a key within the hash table, it exists
@@ -199,7 +199,7 @@ void addToHashTable(OBMap *m, OBDequeIterator *it);
  * @return Index in the hash_table where a result can be found or where a NULL
  * value resides if key was not found
  */
-obhash_t findKeyInHashTable(const OBMap *m, const OBObjType *key);
+obhash_t OBMapGetHashForKey(const OBMap *m, OBTypeRef key);
 
 /**
  * @brief Generates an offset from the hash value to rectify collisions
@@ -209,7 +209,7 @@ obhash_t findKeyInHashTable(const OBMap *m, const OBObjType *key);
  *
  * @return New offset to the next possible location to insert within table
  */
-obhash_t collisionOffset(obhash_t prev_offset);
+obhash_t hash_collision_offset(obhash_t prev_offset);
 
 #endif
 

--- a/include/private/OBString_Private.h
+++ b/include/private/OBString_Private.h
@@ -18,7 +18,7 @@
 struct OBString_struct{
   OBObjType base; /**< obj containing reference count and class membership data */
   char *str; /**< encapsulated NUL terminated C string */
-  uint32_t length; /**< integer tracking str length */
+  size_t length; /**< integer tracking str length */
 };
 
 
@@ -37,7 +37,7 @@ OBString * createDefaultString(void);
  * @param to_hash An obj pointer to an instance of OBString
  * @return Key value (hash) for the given obj pointer to a OBString
  */
-obhash_t hashString(const OBObjType *to_hash);
+obhash_t hashString(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBString
@@ -49,14 +49,14 @@ obhash_t hashString(const OBObjType *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareStrings(const OBObjType *a, const OBObjType *b);
+int8_t compareStrings(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Display function for an instance of OBString
  *
  * @param str A non-NULL obj pointer to type OBString
  */
-void displayString(const OBObjType *str);
+void displayString(OBTypeRef str);
 
 /** 
  * @brief Destructor for OBString
@@ -65,7 +65,7 @@ void displayString(const OBObjType *str);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocString(OBObjType *to_dealloc);
+void deallocString(OBTypeRef to_dealloc);
 
 /* ADDITIONAL PRIVATE METHOD DECLARATIONS HERE*/
 

--- a/include/private/OBString_Private.h
+++ b/include/private/OBString_Private.h
@@ -16,7 +16,7 @@
  * an instance of OBString
  */
 struct OBString_struct{
-  obj base; /**< obj containing reference count and class membership data */
+  OBObjType base; /**< obj containing reference count and class membership data */
   char *str; /**< encapsulated NUL terminated C string */
   uint32_t length; /**< integer tracking str length */
 };
@@ -37,7 +37,7 @@ OBString * createDefaultString(void);
  * @param to_hash An obj pointer to an instance of OBString
  * @return Key value (hash) for the given obj pointer to a OBString
  */
-obhash_t hashString(const obj *to_hash);
+obhash_t hashString(const OBObjType *to_hash);
 
 /**
  * @brief Compares two instances of OBString
@@ -49,14 +49,14 @@ obhash_t hashString(const obj *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareStrings(const obj *a, const obj *b);
+int8_t compareStrings(const OBObjType *a, const OBObjType *b);
 
 /**
  * @brief Display function for an instance of OBString
  *
  * @param str A non-NULL obj pointer to type OBString
  */
-void displayString(const obj *str);
+void displayString(const OBObjType *str);
 
 /** 
  * @brief Destructor for OBString
@@ -65,7 +65,7 @@ void displayString(const obj *str);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocString(obj *to_dealloc);
+void deallocString(OBObjType *to_dealloc);
 
 /* ADDITIONAL PRIVATE METHOD DECLARATIONS HERE*/
 

--- a/include/private/OBString_Private.h
+++ b/include/private/OBString_Private.h
@@ -30,14 +30,14 @@ struct OBString_struct{
  * @warning All public constructors should call this constructor and intialize
  * individual members as needed, so that all base data is initialized properly.
  */
-OBString * createDefaultString(void);
+OBString * OBStringCreateDefault(void);
 
 /**
  * @brief Hash function for OBString
  * @param to_hash An obj pointer to an instance of OBString
  * @return Key value (hash) for the given obj pointer to a OBString
  */
-obhash_t hashString(OBTypeRef to_hash);
+obhash_t OBStringHash(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBString
@@ -49,14 +49,14 @@ obhash_t hashString(OBTypeRef to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareStrings(OBTypeRef a, OBTypeRef b);
+int8_t OBStringCompare(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Display function for an instance of OBString
  *
  * @param str A non-NULL obj pointer to type OBString
  */
-void displayString(OBTypeRef str);
+void OBStringDisplay(OBTypeRef str);
 
 /** 
  * @brief Destructor for OBString
@@ -65,7 +65,7 @@ void displayString(OBTypeRef str);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocString(OBTypeRef to_dealloc);
+void OBStringDealloc(OBTypeRef to_dealloc);
 
 /* ADDITIONAL PRIVATE METHOD DECLARATIONS HERE*/
 

--- a/include/private/OBTest_Private.h
+++ b/include/private/OBTest_Private.h
@@ -25,7 +25,7 @@ struct OBTest_struct{
  * @param to_hash An obj pointer to an instance of OBString
  * @return Key value (hash) for the given obj pointer to a OBString 
  */
-obhash_t hashTest(const OBObjType *to_hash);
+obhash_t hashTest(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBTest
@@ -37,14 +37,14 @@ obhash_t hashTest(const OBObjType *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareTests(const OBObjType *a, const OBObjType *b);
+int8_t compareTests(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Display function for an instance of OBTest
  *
  * @param test A non-NULL obj pointer to type OBTest
  */
-void displayTest(const OBObjType *test);
+void displayTest(OBTypeRef test);
 
 /**
  * @brief Destructor for OBTest
@@ -53,6 +53,6 @@ void displayTest(const OBObjType *test);
  * @warning Do not call manually, release will call automatically when
  * instance reference count drops to 0!
  */
-void deallocTest(OBObjType *to_dealloc);
+void deallocTest(OBTypeRef to_dealloc);
 
 #endif

--- a/include/private/OBTest_Private.h
+++ b/include/private/OBTest_Private.h
@@ -25,7 +25,7 @@ struct OBTest_struct{
  * @param to_hash An obj pointer to an instance of OBString
  * @return Key value (hash) for the given obj pointer to a OBString 
  */
-obhash_t hashTest(OBTypeRef to_hash);
+obhash_t OBTestHash(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBTest
@@ -37,14 +37,14 @@ obhash_t hashTest(OBTypeRef to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareTests(OBTypeRef a, OBTypeRef b);
+int8_t OBTestCompare(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Display function for an instance of OBTest
  *
  * @param test A non-NULL obj pointer to type OBTest
  */
-void displayTest(OBTypeRef test);
+void OBTestDisplay(OBTypeRef test);
 
 /**
  * @brief Destructor for OBTest
@@ -53,6 +53,6 @@ void displayTest(OBTypeRef test);
  * @warning Do not call manually, release will call automatically when
  * instance reference count drops to 0!
  */
-void deallocTest(OBTypeRef to_dealloc);
+void OBTestDealloc(OBTypeRef to_dealloc);
 
 #endif

--- a/include/private/OBTest_Private.h
+++ b/include/private/OBTest_Private.h
@@ -16,7 +16,7 @@
  * of OBTest
  */
 struct OBTest_struct{
-  obj base; /**< obj containing reference count and class membership data */
+  OBObjType base; /**< obj containing reference count and class membership data */
   uint32_t id; /**< integer id to identify different instances of OBTest */
 };
 
@@ -25,7 +25,7 @@ struct OBTest_struct{
  * @param to_hash An obj pointer to an instance of OBString
  * @return Key value (hash) for the given obj pointer to a OBString 
  */
-obhash_t hashTest(const obj *to_hash);
+obhash_t hashTest(const OBObjType *to_hash);
 
 /**
  * @brief Compares two instances of OBTest
@@ -37,14 +37,14 @@ obhash_t hashTest(const obj *to_hash);
  * @retval OB_GREATER_THAN obj a is equivalent to b
  * @retval OB_EQUAL_TO obj a is greater than b
  */
-int8_t compareTests(const obj *a, const obj *b);
+int8_t compareTests(const OBObjType *a, const OBObjType *b);
 
 /**
  * @brief Display function for an instance of OBTest
  *
  * @param test A non-NULL obj pointer to type OBTest
  */
-void displayTest(const obj *test);
+void displayTest(const OBObjType *test);
 
 /**
  * @brief Destructor for OBTest
@@ -53,6 +53,6 @@ void displayTest(const obj *test);
  * @warning Do not call manually, release will call automatically when
  * instance reference count drops to 0!
  */
-void deallocTest(obj *to_dealloc);
+void deallocTest(OBObjType *to_dealloc);
 
 #endif

--- a/include/private/OBVector_Private.h
+++ b/include/private/OBVector_Private.h
@@ -59,7 +59,7 @@ void resizeVector(OBVector *v, uint32_t index);
  * internally.
  */
 OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t order,
-                             compare_fptr funct);
+                             obcompare_fptr funct);
 
 /**
  * @brief Hash function for OBVector

--- a/include/private/OBVector_Private.h
+++ b/include/private/OBVector_Private.h
@@ -17,7 +17,7 @@
  */
 struct OBVector_struct{
   OBObjType base; /**< obj containing reference count and class membership data */
-  OBObjType **array; /**< intenal dynamically sized array of pointers to Offbrand
+  OBTypeRef *array; /**< intenal dynamically sized array of pointers to Offbrand
                     compatible class instances */
   uint32_t length; /**< Integer size to find all objects stored in Vector */
   uint32_t capacity; /**< Integer count of the capacity of the internal array */
@@ -31,7 +31,7 @@ struct OBVector_struct{
  * @param initial_capacity Capacity of the vector to be created
  * @return A new, partially initialized instance of OBVector
  */
-OBVector * createDefaultVector(uint32_t initial_capacity);
+OBVector * OBVectorCreateDefault(uint32_t initial_capacity);
 
 /**
  * @brief Resizes a vector if the number of objects it contains is equal to its
@@ -39,7 +39,7 @@ OBVector * createDefaultVector(uint32_t initial_capacity);
  * @param v Pointer to an instance of OBVector
  * @param index Index that vector must be resized to contain
  */
-void resizeVector(OBVector *v, uint32_t index);
+void OBVectorResize(OBVector *v, uint32_t index);
 
 /**
  * @brief Internal merge sort implementation for an OBVector
@@ -58,7 +58,7 @@ void resizeVector(OBVector *v, uint32_t index);
  * sorting should use the publicly accessable function which calls this method
  * internally.
  */
-OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t order,
+OBTypeRef * recursiveSortContents(OBTypeRef *to_sort, uint32_t size, int8_t order,
                              obcompare_fptr funct);
 
 /**
@@ -66,7 +66,7 @@ OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t or
  * @param to_hash An obj pointer to an instance of OBVector
  * @return Key value (hash) for the given obj pointer to an OBVector
  */
-obhash_t hashVector(OBTypeRef to_hash);
+obhash_t OBVectorHash(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBVector
@@ -77,14 +77,14 @@ obhash_t hashVector(OBTypeRef to_hash);
  * @retval OB_NOT_EQUAL a does not equal b
  * @retval OB_EQUAL_TO a equals b
  */
-int8_t compareVectors(OBTypeRef a, OBTypeRef b);
+int8_t OBVectorCompare(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Display function for an instance of OBString
  *
  * @param to_print A non-NULL obj pointer to type OBString
  */
-void displayVector(OBTypeRef to_print);
+void OBVectorDisplay(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBVector
@@ -93,7 +93,7 @@ void displayVector(OBTypeRef to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocVector(OBTypeRef to_dealloc);
+void OBVectorDealloc(OBTypeRef to_dealloc);
 
 /* PRIVATE UTILITY METHODS */
 
@@ -107,6 +107,6 @@ void deallocVector(OBTypeRef to_dealloc);
  * @retval <UINT32_MAX Index where a non-NULL pointer was found
  * @retval UINT32_MAX No non-NULL pointer was found
  */
-uint32_t findValidPrecursorIndex(OBObjType **array, uint32_t index);
+uint32_t findValidPrecursorIndex(OBTypeRef *array, uint32_t index);
 
 #endif

--- a/include/private/OBVector_Private.h
+++ b/include/private/OBVector_Private.h
@@ -66,7 +66,7 @@ OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t or
  * @param to_hash An obj pointer to an instance of OBVector
  * @return Key value (hash) for the given obj pointer to an OBVector
  */
-obhash_t hashVector(const OBObjType *to_hash);
+obhash_t hashVector(OBTypeRef to_hash);
 
 /**
  * @brief Compares two instances of OBVector
@@ -77,14 +77,14 @@ obhash_t hashVector(const OBObjType *to_hash);
  * @retval OB_NOT_EQUAL a does not equal b
  * @retval OB_EQUAL_TO a equals b
  */
-int8_t compareVectors(const OBObjType *a, const OBObjType *b);
+int8_t compareVectors(OBTypeRef a, OBTypeRef b);
 
 /**
  * @brief Display function for an instance of OBString
  *
  * @param to_print A non-NULL obj pointer to type OBString
  */
-void displayVector(const OBObjType *to_print);
+void displayVector(OBTypeRef to_print);
 
 /** 
  * @brief Destructor for OBVector
@@ -93,7 +93,7 @@ void displayVector(const OBObjType *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocVector(OBObjType *to_dealloc);
+void deallocVector(OBTypeRef to_dealloc);
 
 /* PRIVATE UTILITY METHODS */
 

--- a/include/private/OBVector_Private.h
+++ b/include/private/OBVector_Private.h
@@ -16,8 +16,8 @@
  * an instance of OBVector
  */
 struct OBVector_struct{
-  obj base; /**< obj containing reference count and class membership data */
-  obj **array; /**< intenal dynamically sized array of pointers to Offbrand
+  OBObjType base; /**< obj containing reference count and class membership data */
+  OBObjType **array; /**< intenal dynamically sized array of pointers to Offbrand
                     compatible class instances */
   uint32_t length; /**< Integer size to find all objects stored in Vector */
   uint32_t capacity; /**< Integer count of the capacity of the internal array */
@@ -58,7 +58,7 @@ void resizeVector(OBVector *v, uint32_t index);
  * sorting should use the publicly accessable function which calls this method
  * internally.
  */
-obj ** recursiveSortContents(obj **to_sort, uint32_t size, int8_t order,
+OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t order,
                              compare_fptr funct);
 
 /**
@@ -66,7 +66,7 @@ obj ** recursiveSortContents(obj **to_sort, uint32_t size, int8_t order,
  * @param to_hash An obj pointer to an instance of OBVector
  * @return Key value (hash) for the given obj pointer to an OBVector
  */
-obhash_t hashVector(const obj *to_hash);
+obhash_t hashVector(const OBObjType *to_hash);
 
 /**
  * @brief Compares two instances of OBVector
@@ -77,14 +77,14 @@ obhash_t hashVector(const obj *to_hash);
  * @retval OB_NOT_EQUAL a does not equal b
  * @retval OB_EQUAL_TO a equals b
  */
-int8_t compareVectors(const obj *a, const obj *b);
+int8_t compareVectors(const OBObjType *a, const OBObjType *b);
 
 /**
  * @brief Display function for an instance of OBString
  *
  * @param to_print A non-NULL obj pointer to type OBString
  */
-void displayVector(const obj *to_print);
+void displayVector(const OBObjType *to_print);
 
 /** 
  * @brief Destructor for OBVector
@@ -93,7 +93,7 @@ void displayVector(const obj *to_print);
  * @warning Do not call manually, release will call automatically when the
  * instances reference count drops to 0!
  */
-void deallocVector(obj *to_dealloc);
+void deallocVector(OBObjType *to_dealloc);
 
 /* PRIVATE UTILITY METHODS */
 
@@ -107,6 +107,6 @@ void deallocVector(obj *to_dealloc);
  * @retval <UINT32_MAX Index where a non-NULL pointer was found
  * @retval UINT32_MAX No non-NULL pointer was found
  */
-uint32_t findValidPrecursorIndex(obj **array, uint32_t index);
+uint32_t findValidPrecursorIndex(OBObjType **array, uint32_t index);
 
 #endif

--- a/include/private/obj_Private.h
+++ b/include/private/obj_Private.h
@@ -21,11 +21,11 @@
  * tracks information common to all classes.
  */
 struct OBObjStruct{
-  ref_count_t references; /**< reference count for each instance */
-  dealloc_fptr dealloc; /**< pointer to class specific deallocation function */
-  hash_fptr hash; /**< pointer to class specific hash function */
-  compare_fptr compare; /**< pointer to class specific comparison function */
-  display_fptr display; /**< pointer to the class specific display function */
+  obref_count_t references; /**< reference count for each instance */
+  obdealloc_fptr dealloc; /**< pointer to class specific deallocation function */
+  obhash_fptr hash; /**< pointer to class specific hash function */
+  obcompare_fptr compare; /**< pointer to class specific comparison function */
+  obdisplay_fptr display; /**< pointer to the class specific display function */
   const char *classname; /**< C String classname to which the instance 
                            belongs */
 };

--- a/include/private/obj_Private.h
+++ b/include/private/obj_Private.h
@@ -8,7 +8,7 @@
  * instance of obj as it's base member so that functions can operate generically
  * on all Offbrand classes as if they were objs
  *
- * @author theck
+ * @author theck, danhd123/icodestuff
  */
 
 #ifndef OBJ_PRIVATE_H
@@ -20,7 +20,7 @@
  * @brief Base struct used for within all Offbrand compatible classes that
  * tracks information common to all classes.
  */
-struct obj_struct{
+struct OBObjStruct{
   ref_count_t references; /**< reference count for each instance */
   dealloc_fptr dealloc; /**< pointer to class specific deallocation function */
   hash_fptr hash; /**< pointer to class specific hash function */

--- a/scripts/templates/Source.c
+++ b/scripts/templates/Source.c
@@ -24,7 +24,7 @@
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &dealloc%METHODCLASSNAME%, 
+  initBase(new_instance, &dealloc%METHODCLASSNAME%, 
            &hash%METHODCLASSNAME%, &compare%METHODCLASSNAME%s, 
            &display%METHODCLASSNAME%, classname);
 

--- a/src/classes/OBDeque.c
+++ b/src/classes/OBDeque.c
@@ -11,68 +11,68 @@
 /* PUBLIC METHODS */
 
 
-OBDeque * createDeque(void){
-  return createDefaultDeque();
+OBDeque * OBDequeCreate(void){
+  return OBDequeCreateDefault();
 }
 
 
-OBDeque * copyDeque(const OBDeque *to_copy){
+OBDeque * OBDequeCopy(const OBDeque *to_copy){
 
-  OBObjType *element;
+  OBTypeRef element;
   OBDequeIterator *iter;
   OBDeque *copy;
   
   assert(to_copy);
 
-  copy = createDefaultDeque();
+  copy = OBDequeCreateDefault();
 
-  iter = getDequeHeadIt(to_copy);
+  iter = OBDequeGetHeadIterator(to_copy);
   
   if(!iter) return copy; /* if the list is empty, return empty copy */
 
   /* while there are elements in the deque to copy add to the tail of the
    * deque */
   do{
-    element = objAtDequeIt(to_copy, iter);
-    addDequeTail(copy, element);
-  } while(iterateDequeNext(to_copy, iter));
+    element = OBDequeObjAtIterator(to_copy, iter);
+    OBDequeAddTail(copy, element);
+  } while(OBDequeIterateNext(to_copy, iter));
 
-  OBRelease((OBObjType *)iter);
+  OBRelease(iter);
 
   return copy;
 }
 
 
-uint8_t isDequeEmpty(const OBDeque *deque){
+uint8_t OBDequeIsEmpty(const OBDeque *deque){
   assert(deque);
   return deque->length == 0;
 }
 
 
-uint64_t dequeLength(const OBDeque *deque){
+uint64_t OBDequeLength(const OBDeque *deque){
   assert(deque);
   return deque->length;
 }
 
 
-OBDequeIterator * getDequeHeadIt(const OBDeque *deque){
+OBDequeIterator * OBDequeGetHeadIterator(const OBDeque *deque){
   assert(deque);
-  return createDequeIterator(deque, deque->head);
+  return OBDequeIteratorCreate(deque, deque->head);
 }
 
 
-OBDequeIterator * getDequeTailIt(const OBDeque *deque){
+OBDequeIterator * OBDequeGetTailIterator(const OBDeque *deque){
   assert(deque);
-  return createDequeIterator(deque, deque->tail);
+  return OBDequeIteratorCreate(deque, deque->tail);
 }
 
 
-OBDequeIterator * copyDequeIterator(const OBDequeIterator *it){
-  return createDequeIterator(it->deque, it->node);
+OBDequeIterator * OBDequeIteratorCopy(const OBDequeIterator *it){
+  return OBDequeIteratorCreate(it->deque, it->node);
 }
 
 
-uint8_t iterateDequeNext(const OBDeque *deque, OBDequeIterator *it){
+uint8_t OBDequeIterateNext(const OBDeque *deque, OBDequeIterator *it){
 
   assert(deque);
   assert(it);
@@ -93,7 +93,7 @@ uint8_t iterateDequeNext(const OBDeque *deque, OBDequeIterator *it){
 }
 
 
-uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it){
+uint8_t OBDequeIteratePrevious(const OBDeque *deque, OBDequeIterator *it){
 
   assert(deque);
   assert(it);
@@ -114,7 +114,7 @@ uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it){
 }
 
 
-void addDequeHead(OBDeque *deque, OBObjType *to_add){
+void OBDequeAddHead(OBDeque *deque, OBTypeRef to_add){
   
   OBDequeNode *new_node;
   
@@ -123,7 +123,7 @@ void addDequeHead(OBDeque *deque, OBObjType *to_add){
 
   /* creating deque node with to_add retains to account for the deque's
    * reference */
-  new_node = createDequeNode(to_add);
+  new_node = OBDequeNodeCreate(to_add);
 
   /* set node data */
   new_node->next = deque->head;
@@ -140,7 +140,7 @@ void addDequeHead(OBDeque *deque, OBObjType *to_add){
 }
 
 
-void addDequeTail(OBDeque *deque, OBObjType *to_add){
+void OBDequeAddTail(OBDeque *deque, OBTypeRef to_add){
 
   OBDequeNode *new_node;
   
@@ -149,7 +149,7 @@ void addDequeTail(OBDeque *deque, OBObjType *to_add){
 
   /* creating deque node with to_add retains to account for the deque's
    * reference */
-  new_node = createDequeNode(to_add);
+  new_node = OBDequeNodeCreate(to_add);
 
   /* set node data */
   new_node->prev = deque->tail;
@@ -166,7 +166,7 @@ void addDequeTail(OBDeque *deque, OBObjType *to_add){
 }
 
 
-void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add){
+void OBDeuqueAddAtIterator(OBDeque *deque, OBDequeIterator *it, OBTypeRef to_add){
 
   OBDequeNode *new_node;
   
@@ -176,13 +176,13 @@ void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add){
   assert(to_add);
 
   if(!it->node){
-    addDequeHead(deque, to_add);
+    OBDequeAddHead(deque, to_add);
     it->node = deque->head;
   }
 
   /* creating deque node with to_add retains to account for the deque's
    * reference */
-  new_node = createDequeNode(to_add);
+  new_node = OBDequeNodeCreate(to_add);
 
   /* set node data */
   new_node->prev = it->node->prev;
@@ -197,40 +197,40 @@ void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add){
   if(it->node == deque->head) deque->head = new_node;
 
   /* update iterator to newly inserted node */
-  assert(iterateDequePrev(deque, it));
+  assert(OBDequeIteratePrevious(deque, it));
 
   return;
 }
 
 
-OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2){
+OBDeque * OBDequeJoin(const OBDeque *d1, const OBDeque *d2){
 
   OBDeque *joined;
   OBDequeIterator *it;
-  OBObjType *element;
+  OBTypeRef element;
 
   assert(d1);
   assert(d2);
 
-  joined = copyDeque(d1);
+  joined = OBDequeCopy(d1);
 
-  it = getDequeHeadIt(d2);
+  it = OBDequeGetHeadIterator(d2);
   
   if(!it) return joined; /* if the list is empty, return joined list */
 
   /* while there are elements in the deque to copy add to the tail of the
    * deque */
   do{
-    element = objAtDequeIt(d2, it);
-    addDequeTail(joined, element);
-  } while(iterateDequeNext(d2, it));
+    element = OBDequeObjAtIterator(d2, it);
+    OBDequeAddTail(joined, element);
+  } while(OBDequeIterateNext(d2, it));
 
   OBRelease((OBObjType *)it);
 
   return joined;
 }
 
-uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
+uint8_t OBDequeContains(const OBDeque *deque, OBTypeRef to_find){
 
   OBDequeIterator *it;
   uint8_t retval = 0;
@@ -238,15 +238,15 @@ uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
   assert(deque);
   assert(to_find);
 
-  it = getDequeHeadIt(deque);
+  it = OBDequeGetHeadIterator(deque);
   if(!it) return 0; /* obj is not in an empty list */
   
   do{
-    if(OBCompare(objAtDequeIt(deque, it), to_find) == OB_EQUAL_TO){
+    if(OBCompare(OBDequeObjAtIterator(deque, it), to_find) == OB_EQUAL_TO){
       retval = 1;
       break;
     }
-  } while(iterateDequeNext(deque, it));
+  } while(OBDequeIterateNext(deque, it));
 
   OBRelease((OBObjType *)it);
 
@@ -254,12 +254,12 @@ uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
 }
 
 
-void sortDeque(OBDeque *deque, int8_t order){
-  sortDequeWithFunct(deque, order, &OBCompare);
+void OBDequeSort(OBDeque *deque, int8_t order){
+  OBDequeSortWithFunction(deque, order, &OBCompare);
 }
   
 
-void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct){
+void OBDequeSortWithFunction(OBDeque *deque, int8_t order, obcompare_fptr funct){
 
   OBDeque sorted; /* stack variable to remove internal memory management
                      burden */
@@ -268,7 +268,7 @@ void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct){
   assert(order == OB_LEAST_TO_GREATEST || order == OB_GREATEST_TO_LEAST);
   assert(funct);
 
-  sorted = recursiveSort(*deque, order, funct);
+  sorted = OBDequeSortRecursive(*deque, order, funct);
 
   /* connect head and tail of newly sorted list to deque */
   deque->head = sorted.head;
@@ -278,21 +278,21 @@ void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct){
 }
 
 
-OBObjType * objAtDequeHead(const OBDeque *deque){
+OBTypeRef OBDequeFirstObject(const OBDeque *deque){
   assert(deque);
   if(deque->head) return deque->head->stored;
   return NULL;
 }
 
 
-OBObjType * objAtDequeTail(const OBDeque *deque){
+OBTypeRef OBDequeLastObject(const OBDeque *deque){
   assert(deque);
   if(deque->tail) return deque->tail->stored;
   return NULL;
 }
 
 
-OBObjType * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it){
+OBTypeRef OBDequeObjAtIterator(const OBDeque *deque, const OBDequeIterator *it){
 
   assert(deque);
   assert(it);
@@ -303,7 +303,7 @@ OBObjType * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it){
 }
 
 
-void removeDequeHead(OBDeque *deque){
+void OBDequeRemoveFirstObject(OBDeque *deque){
 
   OBDequeNode *temp_node;
 
@@ -330,7 +330,7 @@ void removeDequeHead(OBDeque *deque){
 }
 
 
-void removeDequeTail(OBDeque *deque){
+void OBDequeRemoveLastObject(OBDeque *deque){
 
   OBDequeNode *temp_node;
 
@@ -357,7 +357,7 @@ void removeDequeTail(OBDeque *deque){
 }
 
 
-void removeDequeAtIt(OBDeque *deque, OBDequeIterator *it){
+void OBDequeRemoveAtIterator(OBDeque *deque, OBDequeIterator *it){
 
   OBDequeNode *temp_node;
 
@@ -378,7 +378,7 @@ void removeDequeAtIt(OBDeque *deque, OBDequeIterator *it){
   temp_node = it->node;
 
   /* advance iterator to next valid node */
-  if(!iterateDequeNext(deque, it) && !iterateDequePrev(deque, it))
+  if(!OBDequeIterateNext(deque, it) && !OBDequeIteratePrevious(deque, it))
     it->node = NULL;
 
   /* set temp_node next and prev to null, to separate the node completely from
@@ -392,7 +392,7 @@ void removeDequeAtIt(OBDeque *deque, OBDequeIterator *it){
 }
 
 
-void clearDeque(OBDeque *deque){
+void OBDequeClear(OBDeque *deque){
 
   OBDequeNode *tmp, *next;
 
@@ -426,7 +426,7 @@ void clearDeque(OBDeque *deque){
 
 /* OBDequeNode Private Methods */
 
-OBDequeNode * createDequeNode(OBObjType *to_store){
+OBDequeNode * OBDequeNodeCreate(OBTypeRef to_store){
 
   static const char classname[] = "OBDequeNode";
   OBDequeNode *new_instance;
@@ -437,7 +437,7 @@ OBDequeNode * createDequeNode(OBObjType *to_store){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  OBInitBase((OBObjType *)new_instance, &deallocDequeNode, NULL, NULL, NULL, classname);
+  OBInitBase((OBObjType *)new_instance, &OBDequeNodeDealloc, NULL, NULL, NULL, classname);
 
   OBRetain(to_store);
   new_instance->stored = to_store;
@@ -448,7 +448,7 @@ OBDequeNode * createDequeNode(OBObjType *to_store){
 }
 
 
-void deallocDequeNode(OBTypeRef to_dealloc){
+void OBDequeNodeDealloc(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBDequeNode */
   OBDequeNode *instance = (OBDequeNode *)to_dealloc;
@@ -464,7 +464,7 @@ void deallocDequeNode(OBTypeRef to_dealloc){
 
 /* OBDequeIterator Private Methods */
 
-OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
+OBDequeIterator * OBDequeIteratorCreate(const OBDeque *deque, OBDequeNode *node){
 
   static const char classname[] = "OBDequeIterator";
   OBDequeIterator *new_instance;
@@ -476,7 +476,7 @@ OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  OBInitBase((OBObjType *)new_instance, &deallocDequeIterator, NULL, NULL, NULL,
+  OBInitBase((OBObjType *)new_instance, &OBDequeIteratorDealloc, NULL, NULL, NULL,
            classname);
 
   OBRetain((OBObjType *)node);
@@ -487,7 +487,7 @@ OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
 }
 
 
-void deallocDequeIterator(OBTypeRef to_dealloc){
+void OBDequeIteratorDealloc(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBDequeNode */
   OBDequeIterator *instance = (OBDequeIterator *)to_dealloc;
@@ -505,15 +505,15 @@ void deallocDequeIterator(OBTypeRef to_dealloc){
 
 /* add arguments to complete initialization as needed, modify 
  * OBDeque_Private.h as well if modifications are made */
-OBDeque * createDefaultDeque(void){
+OBDeque * OBDequeCreateDefault(void){
 
   static const char classname[] = "OBDeque";
   OBDeque *new_instance = malloc(sizeof(OBDeque));
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  OBInitBase((OBObjType *)new_instance, &deallocDeque, &hashDeque, &compareDeques,
-           &displayDeque, classname);
+  OBInitBase((OBObjType *)new_instance, &OBDequeDealloc, &OBDequeHash, &OBDequeCompare,
+           &OBDequeDisplay, classname);
 
   new_instance->head = NULL;
   new_instance->tail = NULL;
@@ -525,7 +525,7 @@ OBDeque * createDefaultDeque(void){
 
 /* private recursive sort method uses stack variables to take advantage of
  * static memory management */
-OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct){
+OBDeque OBDequeSortRecursive(OBDeque deque, int8_t order, obcompare_fptr funct){
 
   uint64_t i, half_length;
   OBDeque left_sorted, right_sorted;
@@ -553,8 +553,8 @@ OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct){
   right_sorted.length = deque.length - half_length;
 
   /* sort deque halves recursively */
-  right_sorted = recursiveSort(right_sorted, order, funct);
-  left_sorted = recursiveSort(left_sorted, order, funct);
+  right_sorted = OBDequeSortRecursive(right_sorted, order, funct);
+  left_sorted = OBDequeSortRecursive(left_sorted, order, funct);
 
   /* set the head of the combined list appropriately */
   if(funct(right_sorted.head->stored, left_sorted.head->stored) == order){
@@ -608,7 +608,7 @@ OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct){
 }
 
 
-obhash_t hashDeque(OBTypeRef to_hash){
+obhash_t OBDequeHash(OBTypeRef to_hash){
 
   static int8_t init = 0;
   obhash_t value;
@@ -627,14 +627,14 @@ obhash_t hashDeque(OBTypeRef to_hash){
 
   value = seed;
 
-  it = getDequeHeadIt(instance);
+  it = OBDequeGetHeadIterator(instance);
   if(!it) return value;
 
   do{
-    value += OBHash(objAtDequeIt(instance, it));
+    value += OBHash(OBDequeObjAtIterator(instance, it));
     value += value << 10;
     value ^= value >> 6;
-  }while(iterateDequeNext(instance, it));
+  }while(OBDequeIterateNext(instance, it));
 
   OBRelease((OBObjType *)it);
 
@@ -646,7 +646,7 @@ obhash_t hashDeque(OBTypeRef to_hash){
 }
 
 
-int8_t compareDeques(OBTypeRef a, OBTypeRef b){
+int8_t OBDequeCompare(OBTypeRef a, OBTypeRef b){
 
   int8_t retval = OB_EQUAL_TO; /* assume equality and disprove if not */
   const OBDeque *comp_a = (OBDeque *)a;
@@ -660,19 +660,19 @@ int8_t compareDeques(OBTypeRef a, OBTypeRef b){
 
   if(comp_a->length != comp_b->length) return OB_NOT_EQUAL;
 
-  a_it = getDequeHeadIt(comp_a);
-  b_it = getDequeHeadIt(comp_b);
+  a_it = OBDequeGetHeadIterator(comp_a);
+  b_it = OBDequeGetHeadIterator(comp_b);
 
   if(!a_it && !b_it) return OB_EQUAL_TO;
 
   if(a_it && b_it){
     do{
-      if(OBCompare(objAtDequeIt(comp_a, a_it), objAtDequeIt(comp_b, b_it)) !=
+      if(OBCompare(OBDequeObjAtIterator(comp_a, a_it), OBDequeObjAtIterator(comp_b, b_it)) !=
        OB_EQUAL_TO){
       retval = OB_NOT_EQUAL;
       break;
     }
-    }while(iterateDequeNext(comp_a, a_it) && iterateDequeNext(comp_b, b_it));
+    }while(OBDequeIterateNext(comp_a, a_it) && OBDequeIterateNext(comp_b, b_it));
   }
   else retval = OB_NOT_EQUAL;
 
@@ -682,7 +682,7 @@ int8_t compareDeques(OBTypeRef a, OBTypeRef b){
   return retval;
 }
 
-void displayDeque(OBTypeRef to_print){
+void OBDequeDisplay(OBTypeRef to_print){
   
   OBDeque *d = (OBDeque *)to_print;
   OBDequeIterator *it;
@@ -690,16 +690,16 @@ void displayDeque(OBTypeRef to_print){
   assert(to_print != NULL);
   assert(OBObjIsOfClass(to_print, "OBDeque"));
   fprintf(stderr, "OBDeque with %llu elements\n"
-                  "  [deque head]", dequeLength(d));
+                  "  [deque head]", OBDequeLength(d));
 
-  it = getDequeHeadIt(d);
+  it = OBDequeGetHeadIterator(d);
 
   if(!it) return;
 
   do{
-    OBDisplay(objAtDequeIt(d, it));
+    OBDisplay(OBDequeObjAtIterator(d, it));
     fprintf(stderr, "\n");
-  }while(iterateDequeNext(d, it));
+  }while(OBDequeIterateNext(d, it));
 
   OBRelease((OBObjType *)it);
 
@@ -709,7 +709,7 @@ void displayDeque(OBTypeRef to_print){
 }
 
 
-void deallocDeque(OBTypeRef to_dealloc){
+void OBDequeDealloc(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBDeque */
   OBDeque *instance = (OBDeque *)to_dealloc;
@@ -717,7 +717,7 @@ void deallocDeque(OBTypeRef to_dealloc){
   assert(to_dealloc);
   assert(OBObjIsOfClass(to_dealloc, "OBDeque"));
 
-  clearDeque(instance);
+  OBDequeClear(instance);
 
   return;
 }

--- a/src/classes/OBDeque.c
+++ b/src/classes/OBDeque.c
@@ -37,7 +37,7 @@ OBDeque * copyDeque(const OBDeque *to_copy){
     addDequeTail(copy, element);
   } while(iterateDequeNext(to_copy, iter));
 
-  release((OBObjType *)iter);
+  OBRelease((OBObjType *)iter);
 
   return copy;
 }
@@ -82,8 +82,8 @@ uint8_t iterateDequeNext(const OBDeque *deque, OBDequeIterator *it){
 
   /* update the iterator if the next node exists, and return 1 */
   if(it->node->next){
-    retain((OBObjType *)it->node->next);
-    release((OBObjType *)it->node);
+    OBRetain((OBObjType *)it->node->next);
+    OBRelease((OBObjType *)it->node);
     it->node = it->node->next;
     return 1;
   }
@@ -103,8 +103,8 @@ uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it){
 
   /* update the iterator if the prev node exists, and return 1 */
   if(it->node->prev){
-    retain((OBObjType *)it->node->prev);
-    release((OBObjType *)it->node);
+    OBRetain((OBObjType *)it->node->prev);
+    OBRelease((OBObjType *)it->node);
     it->node = it->node->prev;
     return 1;
   }
@@ -225,7 +225,7 @@ OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2){
     addDequeTail(joined, element);
   } while(iterateDequeNext(d2, it));
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   return joined;
 }
@@ -248,7 +248,7 @@ uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
     }
   } while(iterateDequeNext(deque, it));
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   return retval;
 }
@@ -259,7 +259,7 @@ void sortDeque(OBDeque *deque, int8_t order){
 }
   
 
-void sortDequeWithFunct(OBDeque *deque, int8_t order, compare_fptr funct){
+void sortDequeWithFunct(OBDeque *deque, int8_t order, obcompare_fptr funct){
 
   OBDeque sorted; /* stack variable to remove internal memory management
                      burden */
@@ -324,7 +324,7 @@ void removeDequeHead(OBDeque *deque){
   temp_node->next = NULL;
   temp_node->prev = NULL;
 
-  release((OBObjType *)temp_node);
+  OBRelease((OBObjType *)temp_node);
 
   return;
 }
@@ -351,7 +351,7 @@ void removeDequeTail(OBDeque *deque){
   temp_node->next = NULL;
   temp_node->prev = NULL;
 
-  release((OBObjType *)temp_node);
+  OBRelease((OBObjType *)temp_node);
 
   return;
 }
@@ -386,7 +386,7 @@ void removeDequeAtIt(OBDeque *deque, OBDequeIterator *it){
   temp_node->next = NULL;
   temp_node->prev = NULL;
 
-  release((OBObjType *)temp_node); /* release reference that deque holds on node */
+  OBRelease((OBObjType *)temp_node); /* release reference that deque holds on node */
 
   return;
 }
@@ -409,7 +409,7 @@ void clearDeque(OBDeque *deque){
     tmp->next = NULL;
     tmp->prev = NULL;
 
-    release((OBObjType *)tmp);
+    OBRelease((OBObjType *)tmp);
     tmp = next;
   }
 
@@ -437,9 +437,9 @@ OBDequeNode * createDequeNode(OBObjType *to_store){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocDequeNode, NULL, NULL, NULL, classname);
+  OBInitBase((OBObjType *)new_instance, &deallocDequeNode, NULL, NULL, NULL, classname);
 
-  retain(to_store);
+  OBRetain(to_store);
   new_instance->stored = to_store;
   new_instance->next = NULL;
   new_instance->prev = NULL;
@@ -456,7 +456,7 @@ void deallocDequeNode(OBObjType *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBDequeNode"));
 
-  release(instance->stored);
+  OBRelease(instance->stored);
 
   return;
 }
@@ -476,10 +476,10 @@ OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocDequeIterator, NULL, NULL, NULL,
+  OBInitBase((OBObjType *)new_instance, &deallocDequeIterator, NULL, NULL, NULL,
            classname);
 
-  retain((OBObjType *)node);
+  OBRetain((OBObjType *)node);
   new_instance->node = node;
   new_instance->deque = deque;
 
@@ -495,7 +495,7 @@ void deallocDequeIterator(OBObjType *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBDequeIterator"));
 
-  release((OBObjType *)instance->node);
+  OBRelease((OBObjType *)instance->node);
 
   return;
 }
@@ -512,7 +512,7 @@ OBDeque * createDefaultDeque(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocDeque, &hashDeque, &compareDeques,
+  OBInitBase((OBObjType *)new_instance, &deallocDeque, &hashDeque, &compareDeques,
            &displayDeque, classname);
 
   new_instance->head = NULL;
@@ -525,7 +525,7 @@ OBDeque * createDefaultDeque(void){
 
 /* private recursive sort method uses stack variables to take advantage of
  * static memory management */
-OBDeque recursiveSort(OBDeque deque, int8_t order, compare_fptr funct){
+OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct){
 
   uint64_t i, half_length;
   OBDeque left_sorted, right_sorted;
@@ -636,7 +636,7 @@ obhash_t hashDeque(const OBObjType *to_hash){
     value ^= value >> 6;
   }while(iterateDequeNext(instance, it));
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   value += value << 3;
   value ^= value >> 11;
@@ -676,8 +676,8 @@ int8_t compareDeques(const OBObjType *a, const OBObjType *b){
   }
   else retval = OB_NOT_EQUAL;
 
-  release((OBObjType *)a_it);
-  release((OBObjType *)b_it);
+  OBRelease((OBObjType *)a_it);
+  OBRelease((OBObjType *)b_it);
   
   return retval;
 }
@@ -701,7 +701,7 @@ void displayDeque(const OBObjType *to_print){
     fprintf(stderr, "\n");
   }while(iterateDequeNext(d, it));
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   fprintf(stderr, "  [deque tail]\n");
 

--- a/src/classes/OBDeque.c
+++ b/src/classes/OBDeque.c
@@ -18,7 +18,7 @@ OBDeque * createDeque(void){
 
 OBDeque * copyDeque(const OBDeque *to_copy){
 
-  obj *element;
+  OBObjType *element;
   OBDequeIterator *iter;
   OBDeque *copy;
   
@@ -37,7 +37,7 @@ OBDeque * copyDeque(const OBDeque *to_copy){
     addDequeTail(copy, element);
   } while(iterateDequeNext(to_copy, iter));
 
-  release((obj *)iter);
+  release((OBObjType *)iter);
 
   return copy;
 }
@@ -82,8 +82,8 @@ uint8_t iterateDequeNext(const OBDeque *deque, OBDequeIterator *it){
 
   /* update the iterator if the next node exists, and return 1 */
   if(it->node->next){
-    retain((obj *)it->node->next);
-    release((obj *)it->node);
+    retain((OBObjType *)it->node->next);
+    release((OBObjType *)it->node);
     it->node = it->node->next;
     return 1;
   }
@@ -103,8 +103,8 @@ uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it){
 
   /* update the iterator if the prev node exists, and return 1 */
   if(it->node->prev){
-    retain((obj *)it->node->prev);
-    release((obj *)it->node);
+    retain((OBObjType *)it->node->prev);
+    release((OBObjType *)it->node);
     it->node = it->node->prev;
     return 1;
   }
@@ -114,7 +114,7 @@ uint8_t iterateDequePrev(const OBDeque *deque, OBDequeIterator *it){
 }
 
 
-void addDequeHead(OBDeque *deque, obj *to_add){
+void addDequeHead(OBDeque *deque, OBObjType *to_add){
   
   OBDequeNode *new_node;
   
@@ -140,7 +140,7 @@ void addDequeHead(OBDeque *deque, obj *to_add){
 }
 
 
-void addDequeTail(OBDeque *deque, obj *to_add){
+void addDequeTail(OBDeque *deque, OBObjType *to_add){
 
   OBDequeNode *new_node;
   
@@ -166,7 +166,7 @@ void addDequeTail(OBDeque *deque, obj *to_add){
 }
 
 
-void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, obj *to_add){
+void addAtDequeIt(OBDeque *deque, OBDequeIterator *it, OBObjType *to_add){
 
   OBDequeNode *new_node;
   
@@ -207,7 +207,7 @@ OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2){
 
   OBDeque *joined;
   OBDequeIterator *it;
-  obj *element;
+  OBObjType *element;
 
   assert(d1);
   assert(d2);
@@ -225,12 +225,12 @@ OBDeque * joinDeques(const OBDeque *d1, const OBDeque *d2){
     addDequeTail(joined, element);
   } while(iterateDequeNext(d2, it));
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   return joined;
 }
 
-uint8_t findObjInDeque(const OBDeque *deque, const obj *to_find){
+uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
 
   OBDequeIterator *it;
   uint8_t retval = 0;
@@ -248,7 +248,7 @@ uint8_t findObjInDeque(const OBDeque *deque, const obj *to_find){
     }
   } while(iterateDequeNext(deque, it));
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   return retval;
 }
@@ -278,21 +278,21 @@ void sortDequeWithFunct(OBDeque *deque, int8_t order, compare_fptr funct){
 }
 
 
-obj * objAtDequeHead(const OBDeque *deque){
+OBObjType * objAtDequeHead(const OBDeque *deque){
   assert(deque);
   if(deque->head) return deque->head->stored;
   return NULL;
 }
 
 
-obj * objAtDequeTail(const OBDeque *deque){
+OBObjType * objAtDequeTail(const OBDeque *deque){
   assert(deque);
   if(deque->tail) return deque->tail->stored;
   return NULL;
 }
 
 
-obj * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it){
+OBObjType * objAtDequeIt(const OBDeque *deque, const OBDequeIterator *it){
 
   assert(deque);
   assert(it);
@@ -324,7 +324,7 @@ void removeDequeHead(OBDeque *deque){
   temp_node->next = NULL;
   temp_node->prev = NULL;
 
-  release((obj *)temp_node);
+  release((OBObjType *)temp_node);
 
   return;
 }
@@ -351,7 +351,7 @@ void removeDequeTail(OBDeque *deque){
   temp_node->next = NULL;
   temp_node->prev = NULL;
 
-  release((obj *)temp_node);
+  release((OBObjType *)temp_node);
 
   return;
 }
@@ -386,7 +386,7 @@ void removeDequeAtIt(OBDeque *deque, OBDequeIterator *it){
   temp_node->next = NULL;
   temp_node->prev = NULL;
 
-  release((obj *)temp_node); /* release reference that deque holds on node */
+  release((OBObjType *)temp_node); /* release reference that deque holds on node */
 
   return;
 }
@@ -409,7 +409,7 @@ void clearDeque(OBDeque *deque){
     tmp->next = NULL;
     tmp->prev = NULL;
 
-    release((obj *)tmp);
+    release((OBObjType *)tmp);
     tmp = next;
   }
 
@@ -426,7 +426,7 @@ void clearDeque(OBDeque *deque){
 
 /* OBDequeNode Private Methods */
 
-OBDequeNode * createDequeNode(obj *to_store){
+OBDequeNode * createDequeNode(OBObjType *to_store){
 
   static const char classname[] = "OBDequeNode";
   OBDequeNode *new_instance;
@@ -437,7 +437,7 @@ OBDequeNode * createDequeNode(obj *to_store){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocDequeNode, NULL, NULL, NULL, classname);
+  initBase((OBObjType *)new_instance, &deallocDequeNode, NULL, NULL, NULL, classname);
 
   retain(to_store);
   new_instance->stored = to_store;
@@ -448,7 +448,7 @@ OBDequeNode * createDequeNode(obj *to_store){
 }
 
 
-void deallocDequeNode(obj *to_dealloc){
+void deallocDequeNode(OBObjType *to_dealloc){
 
   /* cast generic obj to OBDequeNode */
   OBDequeNode *instance = (OBDequeNode *)to_dealloc;
@@ -476,10 +476,10 @@ OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocDequeIterator, NULL, NULL, NULL,
+  initBase((OBObjType *)new_instance, &deallocDequeIterator, NULL, NULL, NULL,
            classname);
 
-  retain((obj *)node);
+  retain((OBObjType *)node);
   new_instance->node = node;
   new_instance->deque = deque;
 
@@ -487,7 +487,7 @@ OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
 }
 
 
-void deallocDequeIterator(obj *to_dealloc){
+void deallocDequeIterator(OBObjType *to_dealloc){
 
   /* cast generic obj to OBDequeNode */
   OBDequeIterator *instance = (OBDequeIterator *)to_dealloc;
@@ -495,7 +495,7 @@ void deallocDequeIterator(obj *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBDequeIterator"));
 
-  release((obj *)instance->node);
+  release((OBObjType *)instance->node);
 
   return;
 }
@@ -512,7 +512,7 @@ OBDeque * createDefaultDeque(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocDeque, &hashDeque, &compareDeques,
+  initBase((OBObjType *)new_instance, &deallocDeque, &hashDeque, &compareDeques,
            &displayDeque, classname);
 
   new_instance->head = NULL;
@@ -608,7 +608,7 @@ OBDeque recursiveSort(OBDeque deque, int8_t order, compare_fptr funct){
 }
 
 
-obhash_t hashDeque(const obj *to_hash){
+obhash_t hashDeque(const OBObjType *to_hash){
 
   static int8_t init = 0;
   obhash_t value;
@@ -636,7 +636,7 @@ obhash_t hashDeque(const obj *to_hash){
     value ^= value >> 6;
   }while(iterateDequeNext(instance, it));
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   value += value << 3;
   value ^= value >> 11;
@@ -646,7 +646,7 @@ obhash_t hashDeque(const obj *to_hash){
 }
 
 
-int8_t compareDeques(const obj *a, const obj *b){
+int8_t compareDeques(const OBObjType *a, const OBObjType *b){
 
   int8_t retval = OB_EQUAL_TO; /* assume equality and disprove if not */
   const OBDeque *comp_a = (OBDeque *)a;
@@ -676,13 +676,13 @@ int8_t compareDeques(const obj *a, const obj *b){
   }
   else retval = OB_NOT_EQUAL;
 
-  release((obj *)a_it);
-  release((obj *)b_it);
+  release((OBObjType *)a_it);
+  release((OBObjType *)b_it);
   
   return retval;
 }
 
-void displayDeque(const obj *to_print){
+void displayDeque(const OBObjType *to_print){
   
   OBDeque *d = (OBDeque *)to_print;
   OBDequeIterator *it;
@@ -701,7 +701,7 @@ void displayDeque(const obj *to_print){
     fprintf(stderr, "\n");
   }while(iterateDequeNext(d, it));
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   fprintf(stderr, "  [deque tail]\n");
 
@@ -709,7 +709,7 @@ void displayDeque(const obj *to_print){
 }
 
 
-void deallocDeque(obj *to_dealloc){
+void deallocDeque(OBObjType *to_dealloc){
 
   /* cast generic obj to OBDeque */
   OBDeque *instance = (OBDeque *)to_dealloc;

--- a/src/classes/OBDeque.c
+++ b/src/classes/OBDeque.c
@@ -33,7 +33,7 @@ OBDeque * OBDequeCopy(const OBDeque *to_copy){
   /* while there are elements in the deque to copy add to the tail of the
    * deque */
   do{
-    element = OBDequeObjAtIterator(to_copy, iter);
+    element = OBDequeGetObjectAtIterator(to_copy, iter);
     OBDequeAddTail(copy, element);
   } while(OBDequeIterateNext(to_copy, iter));
 
@@ -49,7 +49,7 @@ uint8_t OBDequeIsEmpty(const OBDeque *deque){
 }
 
 
-uint64_t OBDequeLength(const OBDeque *deque){
+uint64_t OBDequeGetLength(const OBDeque *deque){
   assert(deque);
   return deque->length;
 }
@@ -221,7 +221,7 @@ OBDeque * OBDequeJoin(const OBDeque *d1, const OBDeque *d2){
   /* while there are elements in the deque to copy add to the tail of the
    * deque */
   do{
-    element = OBDequeObjAtIterator(d2, it);
+    element = OBDequeGetObjectAtIterator(d2, it);
     OBDequeAddTail(joined, element);
   } while(OBDequeIterateNext(d2, it));
 
@@ -242,7 +242,7 @@ uint8_t OBDequeContains(const OBDeque *deque, OBTypeRef to_find){
   if(!it) return 0; /* obj is not in an empty list */
   
   do{
-    if(OBCompare(OBDequeObjAtIterator(deque, it), to_find) == OB_EQUAL_TO){
+    if(OBCompare(OBDequeGetObjectAtIterator(deque, it), to_find) == OB_EQUAL_TO){
       retval = 1;
       break;
     }
@@ -278,21 +278,21 @@ void OBDequeSortWithFunction(OBDeque *deque, int8_t order, obcompare_fptr funct)
 }
 
 
-OBTypeRef OBDequeFirstObject(const OBDeque *deque){
+OBTypeRef OBDequeGetFirstObject(const OBDeque *deque){
   assert(deque);
   if(deque->head) return deque->head->stored;
   return NULL;
 }
 
 
-OBTypeRef OBDequeLastObject(const OBDeque *deque){
+OBTypeRef OBDequeGetLastObject(const OBDeque *deque){
   assert(deque);
   if(deque->tail) return deque->tail->stored;
   return NULL;
 }
 
 
-OBTypeRef OBDequeObjAtIterator(const OBDeque *deque, const OBDequeIterator *it){
+OBTypeRef OBDequeGetObjectAtIterator(const OBDeque *deque, const OBDequeIterator *it){
 
   assert(deque);
   assert(it);
@@ -357,7 +357,7 @@ void OBDequeRemoveLastObject(OBDeque *deque){
 }
 
 
-void OBDequeRemoveAtIterator(OBDeque *deque, OBDequeIterator *it){
+void OBDequeRemoveObjectAtIterator(OBDeque *deque, OBDequeIterator *it){
 
   OBDequeNode *temp_node;
 
@@ -631,7 +631,7 @@ obhash_t OBDequeHash(OBTypeRef to_hash){
   if(!it) return value;
 
   do{
-    value += OBHash(OBDequeObjAtIterator(instance, it));
+    value += OBHash(OBDequeGetObjectAtIterator(instance, it));
     value += value << 10;
     value ^= value >> 6;
   }while(OBDequeIterateNext(instance, it));
@@ -667,7 +667,7 @@ int8_t OBDequeCompare(OBTypeRef a, OBTypeRef b){
 
   if(a_it && b_it){
     do{
-      if(OBCompare(OBDequeObjAtIterator(comp_a, a_it), OBDequeObjAtIterator(comp_b, b_it)) !=
+      if(OBCompare(OBDequeGetObjectAtIterator(comp_a, a_it), OBDequeGetObjectAtIterator(comp_b, b_it)) !=
        OB_EQUAL_TO){
       retval = OB_NOT_EQUAL;
       break;
@@ -690,14 +690,14 @@ void OBDequeDisplay(OBTypeRef to_print){
   assert(to_print != NULL);
   assert(OBObjIsOfClass(to_print, "OBDeque"));
   fprintf(stderr, "OBDeque with %llu elements\n"
-                  "  [deque head]", OBDequeLength(d));
+                  "  [deque head]", OBDequeGetLength(d));
 
   it = OBDequeGetHeadIterator(d);
 
   if(!it) return;
 
   do{
-    OBDisplay(OBDequeObjAtIterator(d, it));
+    OBDisplay(OBDequeGetObjectAtIterator(d, it));
     fprintf(stderr, "\n");
   }while(OBDequeIterateNext(d, it));
 

--- a/src/classes/OBDeque.c
+++ b/src/classes/OBDeque.c
@@ -242,7 +242,7 @@ uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
   if(!it) return 0; /* obj is not in an empty list */
   
   do{
-    if(compare(objAtDequeIt(deque, it), to_find) == OB_EQUAL_TO){
+    if(OBCompare(objAtDequeIt(deque, it), to_find) == OB_EQUAL_TO){
       retval = 1;
       break;
     }
@@ -255,7 +255,7 @@ uint8_t findObjInDeque(const OBDeque *deque, const OBObjType *to_find){
 
 
 void sortDeque(OBDeque *deque, int8_t order){
-  sortDequeWithFunct(deque, order, &compare);
+  sortDequeWithFunct(deque, order, &OBCompare);
 }
   
 
@@ -448,13 +448,13 @@ OBDequeNode * createDequeNode(OBObjType *to_store){
 }
 
 
-void deallocDequeNode(OBObjType *to_dealloc){
+void deallocDequeNode(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBDequeNode */
   OBDequeNode *instance = (OBDequeNode *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBDequeNode"));
+  assert(OBObjIsOfClass(to_dealloc, "OBDequeNode"));
 
   OBRelease(instance->stored);
 
@@ -487,13 +487,13 @@ OBDequeIterator * createDequeIterator(const OBDeque *deque, OBDequeNode *node){
 }
 
 
-void deallocDequeIterator(OBObjType *to_dealloc){
+void deallocDequeIterator(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBDequeNode */
   OBDequeIterator *instance = (OBDequeIterator *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBDequeIterator"));
+  assert(OBObjIsOfClass(to_dealloc, "OBDequeIterator"));
 
   OBRelease((OBObjType *)instance->node);
 
@@ -608,7 +608,7 @@ OBDeque recursiveSort(OBDeque deque, int8_t order, obcompare_fptr funct){
 }
 
 
-obhash_t hashDeque(const OBObjType *to_hash){
+obhash_t hashDeque(OBTypeRef to_hash){
 
   static int8_t init = 0;
   obhash_t value;
@@ -617,7 +617,7 @@ obhash_t hashDeque(const OBObjType *to_hash){
   OBDequeIterator *it;
 
   assert(to_hash);
-  assert(objIsOfClass(to_hash, "OBDeque"));
+  assert(OBObjIsOfClass(to_hash, "OBDeque"));
   
   if(init == 0){
     srand(time(NULL));
@@ -631,7 +631,7 @@ obhash_t hashDeque(const OBObjType *to_hash){
   if(!it) return value;
 
   do{
-    value += hash(objAtDequeIt(instance, it));
+    value += OBHash(objAtDequeIt(instance, it));
     value += value << 10;
     value ^= value >> 6;
   }while(iterateDequeNext(instance, it));
@@ -646,7 +646,7 @@ obhash_t hashDeque(const OBObjType *to_hash){
 }
 
 
-int8_t compareDeques(const OBObjType *a, const OBObjType *b){
+int8_t compareDeques(OBTypeRef a, OBTypeRef b){
 
   int8_t retval = OB_EQUAL_TO; /* assume equality and disprove if not */
   const OBDeque *comp_a = (OBDeque *)a;
@@ -655,8 +655,8 @@ int8_t compareDeques(const OBObjType *a, const OBObjType *b){
 
   assert(a);
   assert(b);
-  assert(objIsOfClass(a, "OBDeque"));
-  assert(objIsOfClass(b, "OBDeque"));
+  assert(OBObjIsOfClass(a, "OBDeque"));
+  assert(OBObjIsOfClass(b, "OBDeque"));
 
   if(comp_a->length != comp_b->length) return OB_NOT_EQUAL;
 
@@ -667,7 +667,7 @@ int8_t compareDeques(const OBObjType *a, const OBObjType *b){
 
   if(a_it && b_it){
     do{
-      if(compare(objAtDequeIt(comp_a, a_it), objAtDequeIt(comp_b, b_it)) !=
+      if(OBCompare(objAtDequeIt(comp_a, a_it), objAtDequeIt(comp_b, b_it)) !=
        OB_EQUAL_TO){
       retval = OB_NOT_EQUAL;
       break;
@@ -682,13 +682,13 @@ int8_t compareDeques(const OBObjType *a, const OBObjType *b){
   return retval;
 }
 
-void displayDeque(const OBObjType *to_print){
+void displayDeque(OBTypeRef to_print){
   
   OBDeque *d = (OBDeque *)to_print;
   OBDequeIterator *it;
 
   assert(to_print != NULL);
-  assert(objIsOfClass(to_print, "OBDeque"));
+  assert(OBObjIsOfClass(to_print, "OBDeque"));
   fprintf(stderr, "OBDeque with %llu elements\n"
                   "  [deque head]", dequeLength(d));
 
@@ -697,7 +697,7 @@ void displayDeque(const OBObjType *to_print){
   if(!it) return;
 
   do{
-    display(objAtDequeIt(d, it));
+    OBDisplay(objAtDequeIt(d, it));
     fprintf(stderr, "\n");
   }while(iterateDequeNext(d, it));
 
@@ -709,13 +709,13 @@ void displayDeque(const OBObjType *to_print){
 }
 
 
-void deallocDeque(OBObjType *to_dealloc){
+void deallocDeque(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBDeque */
   OBDeque *instance = (OBDeque *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBDeque"));
+  assert(OBObjIsOfClass(to_dealloc, "OBDeque"));
 
   clearDeque(instance);
 

--- a/src/classes/OBInt.c
+++ b/src/classes/OBInt.c
@@ -67,7 +67,7 @@ OBInt * intFromString(const OBString *numstr){
   int8_t offset, sign;
 
   int32_t num;
-  uint32_t strlen, i;
+  size_t strlen, i;
   uint64_t digits;
   OBInt *instance;
 
@@ -374,7 +374,7 @@ OBInt * createDefaultInt(uint64_t num_digits){
 }
 
 
-obhash_t hashInt(const OBObjType *to_hash){
+obhash_t hashInt(OBTypeRef to_hash){
 
   static int8_t init = 0;
   static obhash_t seed = 0;
@@ -384,7 +384,7 @@ obhash_t hashInt(const OBObjType *to_hash){
   OBInt *instance = (OBInt *)to_hash;
 
   assert(to_hash);
-  assert(objIsOfClass(to_hash, "OBInt"));
+  assert(OBObjIsOfClass(to_hash, "OBInt"));
 
   if(init == 0){
     srand(time(NULL));
@@ -410,7 +410,7 @@ obhash_t hashInt(const OBObjType *to_hash){
 }
 
 
-int8_t compareInts(const OBObjType *a, const OBObjType *b){
+int8_t compareInts(OBTypeRef a, OBTypeRef b){
   
   int8_t magnitude_comp;
   const OBInt *comp_a = (OBInt *)a;  
@@ -418,8 +418,8 @@ int8_t compareInts(const OBObjType *a, const OBObjType *b){
 
   assert(a);
   assert(b);
-  assert(objIsOfClass(a, "OBInt"));
-  assert(objIsOfClass(b, "OBInt"));
+  assert(OBObjIsOfClass(a, "OBInt"));
+  assert(OBObjIsOfClass(b, "OBInt"));
 
   /* if signs are equal magnitude comparision is required */
   if(comp_a->sign == comp_b->sign){
@@ -460,13 +460,13 @@ int8_t compareMagnitudes(const OBInt *a, const OBInt *b){
 }
 
 
-void displayInt(const OBObjType *to_print){
+void displayInt(OBTypeRef to_print){
 
   OBString *str;
   const OBInt *instance = (OBInt *)to_print;
   
   assert(to_print);
-  assert(objIsOfClass(to_print, "OBInt"));
+  assert(OBObjIsOfClass(to_print, "OBInt"));
 
   str = stringFromInt(instance);
   fprintf(stderr, "Value:\n  %s\n", getCString(str));
@@ -477,13 +477,13 @@ void displayInt(const OBObjType *to_print){
 }
 
 
-void deallocInt(OBObjType *to_dealloc){
+void deallocInt(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBInt */
   OBInt *instance = (OBInt *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBInt"));
+  assert(OBObjIsOfClass(to_dealloc, "OBInt"));
 
   free(instance->digits);
 

--- a/src/classes/OBInt.c
+++ b/src/classes/OBInt.c
@@ -202,7 +202,7 @@ OBInt * addIntAndPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = addInts(a, wrapper);
-  release((OBObjType *)wrapper);
+  OBRelease((OBObjType *)wrapper);
 
   return result;
 }
@@ -250,7 +250,7 @@ OBInt * subtractIntWithPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = subtractInts(a, wrapper);
-  release((OBObjType *)wrapper);
+  OBRelease((OBObjType *)wrapper);
 
   return result;
 }
@@ -278,7 +278,7 @@ OBInt * multiplyIntAndPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = multiplyInts(a, wrapper);
-  release((OBObjType *)wrapper);
+  OBRelease((OBObjType *)wrapper);
 
   return result;
 }
@@ -295,7 +295,7 @@ OBInt * divideInts(const OBInt *a, const OBInt *b){
   seed = createIntWithInt(0);
   result = reduceUnsignedInts(a, b, seed, 1);
   result->sign = a->sign * b->sign;
-  release((OBObjType *)seed);
+  OBRelease((OBObjType *)seed);
 
   return result;
 }
@@ -310,7 +310,7 @@ OBInt * divideIntWithPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = divideInts(a, wrapper);
-  release((OBObjType *)wrapper);
+  OBRelease((OBObjType *)wrapper);
 
   return result;
 }
@@ -327,7 +327,7 @@ OBInt * modInts(const OBInt *a, const OBInt *b){
   seed = createIntWithInt(0);
   result = reduceUnsignedInts(a, b, seed, 0);
   result->sign = a->sign;
-  release((OBObjType *)seed);
+  OBRelease((OBObjType *)seed);
 
   return result;
 }
@@ -342,7 +342,7 @@ OBInt * modIntWithPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = modInts(a, wrapper);
-  release((OBObjType *)wrapper);
+  OBRelease((OBObjType *)wrapper);
 
   return result;
 }
@@ -359,7 +359,7 @@ OBInt * createDefaultInt(uint64_t num_digits){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocInt, &hashInt, &compareInts, 
+  OBInitBase((OBObjType *)new_instance, &deallocInt, &hashInt, &compareInts, 
            &displayInt, classname);
 
   new_instance->sign = 1; /* positive by default */
@@ -471,7 +471,7 @@ void displayInt(const OBObjType *to_print){
   str = stringFromInt(instance);
   fprintf(stderr, "Value:\n  %s\n", getCString(str));
   
-  release((OBObjType *)str);
+  OBRelease((OBObjType *)str);
 
   return;
 }
@@ -585,29 +585,29 @@ OBInt * multiplyUnsignedInts(const OBInt *a, const OBInt *b){
   z1b = addUnsignedInts(y1, y0);
   z1c = multiplyUnsignedInts(z1a, z1b);
 
-  release((OBObjType *)x0);
-  release((OBObjType *)x1);
-  release((OBObjType *)y0);
-  release((OBObjType *)y1);
-  release((OBObjType *)z1a);
-  release((OBObjType *)z1b);
+  OBRelease((OBObjType *)x0);
+  OBRelease((OBObjType *)x1);
+  OBRelease((OBObjType *)y0);
+  OBRelease((OBObjType *)y1);
+  OBRelease((OBObjType *)z1a);
+  OBRelease((OBObjType *)z1b);
 
   z1d = subtractUnsignedInts(z1c, z2);
-  release((OBObjType *)z1c);
+  OBRelease((OBObjType *)z1c);
   z1 = subtractUnsignedInts(z1d, z0);
-  release((OBObjType *)z1d);
+  OBRelease((OBObjType *)z1d);
 
   shiftInt(z2, 2*split_point);
   shiftInt(z1, split_point);
   partial_result = addUnsignedInts(z2, z1);
 
-  release((OBObjType *) z2);
-  release((OBObjType *) z1);
+  OBRelease((OBObjType *) z2);
+  OBRelease((OBObjType *) z1);
 
   result = addUnsignedInts(partial_result, z0);
   
-  release((OBObjType *) partial_result);
-  release((OBObjType *) z0);
+  OBRelease((OBObjType *) partial_result);
+  OBRelease((OBObjType *) z0);
 
   return result;
 }
@@ -638,7 +638,7 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
       result_val = a_val/b_val;
       partial = createIntWithInt(result_val);
       result = addInts(approx, partial);
-      release((OBObjType *)partial);
+      OBRelease((OBObjType *)partial);
     }
     else{
       result_val = a_val%b_val;
@@ -700,8 +700,8 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
   /* if approximation is too great then increment b_val to account for remaining
    * portion of b that is causing over approximation */
   if(comp_val == OB_GREATER_THAN){
-    release((OBObjType *)partial);
-    release((OBObjType *)product);
+    OBRelease((OBObjType *)partial);
+    OBRelease((OBObjType *)product);
 
     b_val++; 
     partial = createIntWithInt(a_val/b_val);
@@ -710,14 +710,14 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
   }
 
   new_dividend = subtractUnsignedInts(a, product);
-  release((OBObjType *)product);
+  OBRelease((OBObjType *)product);
   new_approx = addUnsignedInts(approx, partial);
-  release((OBObjType *)partial);
+  OBRelease((OBObjType *)partial);
 
   result = reduceUnsignedInts(new_dividend, b, new_approx, quotient);
 
-  release((OBObjType *)new_approx);
-  release((OBObjType *)new_dividend);
+  OBRelease((OBObjType *)new_approx);
+  OBRelease((OBObjType *)new_dividend);
 
   return result;
 }

--- a/src/classes/OBInt.c
+++ b/src/classes/OBInt.c
@@ -12,7 +12,7 @@ uint8_t int64_max_digits = 17;
 
 /* PUBLIC METHODS */
 
-OBInt * createIntWithInt(int64_t num){
+OBInt * OBIntCreate(int64_t num){
   
   uint64_t i, ds;
   int64_t partial_num;
@@ -44,7 +44,7 @@ OBInt * createIntWithInt(int64_t num){
 }
 
 
-int64_t intValue(const OBInt *a){
+int64_t OBIntGetIntValue(const OBInt *a){
 
   uint64_t i, most_sig;
   int64_t val;
@@ -62,7 +62,7 @@ int64_t intValue(const OBInt *a){
 }
 
 
-OBInt * intFromString(const OBString *numstr){ 
+OBInt * OBIntCreateFromString(const OBString *numstr){ 
 
   int8_t offset, sign;
 
@@ -95,13 +95,13 @@ OBInt * intFromString(const OBString *numstr){
   }
 
   /* zero is defined to be positive */
-  if(isIntZero(instance)) instance->sign = 1;
+  if(OBIntIsZero(instance)) instance->sign = 1;
 
   return instance;
 }
 
 
-OBString * stringFromInt(const OBInt *a){
+OBString * OBIntGetStringValue(const OBInt *a){
 
   uint8_t offset = 0;
   uint64_t most_sig, i;
@@ -126,7 +126,7 @@ OBString * stringFromInt(const OBInt *a){
 }
 
 
-OBInt * copyInt(const OBInt *a){
+OBInt * OBIntCopy(const OBInt *a){
 
   uint64_t i, most_sig;
   OBInt *copy;
@@ -143,7 +143,7 @@ OBInt * copyInt(const OBInt *a){
 }
 
 
-uint8_t isIntZero(const OBInt *a){
+uint8_t OBIntIsZero(const OBInt *a){
 
   uint64_t most_sig;
 
@@ -154,13 +154,13 @@ uint8_t isIntZero(const OBInt *a){
 }
 
 
-uint8_t isIntNegative(const OBInt *a){ 
+uint8_t OBIntIsNegative(const OBInt *a){ 
   assert(a != NULL);
   return a->sign == -1;
 }
 
 
-OBInt * addInts(const OBInt *a, const OBInt *b){ 
+OBInt * OBIntAdd(const OBInt *a, const OBInt *b){ 
 
   int8_t cmp_result;
   OBInt *result;
@@ -169,8 +169,8 @@ OBInt * addInts(const OBInt *a, const OBInt *b){
   assert(b != NULL);
 
   /* a and b are  of same sign */
-  if((isIntNegative(a) && isIntNegative(b)) || 
-     (!isIntNegative(a) && !isIntNegative(b))){
+  if((OBIntIsNegative(a) && OBIntIsNegative(b)) || 
+     (!OBIntIsNegative(a) && !OBIntIsNegative(b))){
     result = addUnsignedInts(a,b);
     result->sign = a->sign;
     return result;
@@ -190,25 +190,25 @@ OBInt * addInts(const OBInt *a, const OBInt *b){
   }
 
   /* a and b are equal and opposite, result is 0 */
-  return createIntWithInt(0);
+  return OBIntCreate(0);
 }
 
 
-OBInt * addIntAndPrim(const OBInt *a, int64_t b){ 
+OBInt * OBIntAddPrimitive(const OBInt *a, int64_t b){ 
 
   OBInt *wrapper, *result;
 
   assert(a != NULL);
 
-  wrapper = createIntWithInt(b);
-  result = addInts(a, wrapper);
+  wrapper = OBIntCreate(b);
+  result = OBIntAdd(a, wrapper);
   OBRelease((OBObjType *)wrapper);
 
   return result;
 }
 
 
-OBInt * subtractInts(const OBInt *a, const OBInt *b){ 
+OBInt * OBIntSubtract(const OBInt *a, const OBInt *b){ 
 
   int8_t cmp_result;
   OBInt *result;
@@ -217,8 +217,8 @@ OBInt * subtractInts(const OBInt *a, const OBInt *b){
   assert(b != NULL);
 
   /* a and b are  of opposite sign */
-  if((!isIntNegative(a) && isIntNegative(b)) || 
-     (isIntNegative(a) && !isIntNegative(b))){
+  if((!OBIntIsNegative(a) && OBIntIsNegative(b)) || 
+     (OBIntIsNegative(a) && !OBIntIsNegative(b))){
     result = addUnsignedInts(a,b);
     result->sign = a->sign;
     return result;
@@ -238,25 +238,25 @@ OBInt * subtractInts(const OBInt *a, const OBInt *b){
   }
 
   /* a and b are equal and same, result is 0 */
-  return createIntWithInt(0);
+  return OBIntCreate(0);
 }
 
 
-OBInt * subtractIntWithPrim(const OBInt *a, int64_t b){
+OBInt * OBIntSubtractPrimitive(const OBInt *a, int64_t b){
 
   OBInt *wrapper, *result;
 
   assert(a != NULL);
 
-  wrapper = createIntWithInt(b);
-  result = subtractInts(a, wrapper);
+  wrapper = OBIntCreate(b);
+  result = OBIntSubtract(a, wrapper);
   OBRelease((OBObjType *)wrapper);
 
   return result;
 }
 
 
-OBInt * multiplyInts(const OBInt *a, const OBInt *b){
+OBInt * OBIntMultiply(const OBInt *a, const OBInt *b){
 
   OBInt *result;
 
@@ -270,29 +270,29 @@ OBInt * multiplyInts(const OBInt *a, const OBInt *b){
 }
 
 
-OBInt * multiplyIntAndPrim(const OBInt *a, int64_t b){
+OBInt * OBIntMultiplyPrimitive(const OBInt *a, int64_t b){
 
   OBInt *wrapper, *result;
 
   assert(a != NULL);
 
-  wrapper = createIntWithInt(b);
-  result = multiplyInts(a, wrapper);
+  wrapper = OBIntCreate(b);
+  result = OBIntMultiply(a, wrapper);
   OBRelease((OBObjType *)wrapper);
 
   return result;
 }
 
 
-OBInt * divideInts(const OBInt *a, const OBInt *b){
+OBInt * OBIntDivide(const OBInt *a, const OBInt *b){
 
   OBInt *result, *seed;
 
   assert(a != NULL);
   assert(b != NULL);
-  assert(isIntZero(b) == 0);
+  assert(OBIntIsZero(b) == 0);
 
-  seed = createIntWithInt(0);
+  seed = OBIntCreate(0);
   result = reduceUnsignedInts(a, b, seed, 1);
   result->sign = a->sign * b->sign;
   OBRelease((OBObjType *)seed);
@@ -301,30 +301,30 @@ OBInt * divideInts(const OBInt *a, const OBInt *b){
 }
 
 
-OBInt * divideIntWithPrim(const OBInt *a, int64_t b){
+OBInt * OBIntDividePrimitive(const OBInt *a, int64_t b){
 
   OBInt *wrapper, *result;
 
   assert(a != NULL);
   assert(b != 0);
 
-  wrapper = createIntWithInt(b);
-  result = divideInts(a, wrapper);
+  wrapper = OBIntCreate(b);
+  result = OBIntDivide(a, wrapper);
   OBRelease((OBObjType *)wrapper);
 
   return result;
 }
 
 
-OBInt * modInts(const OBInt *a, const OBInt *b){
+OBInt * OBIntMod(const OBInt *a, const OBInt *b){
 
   OBInt *result, *seed;
 
   assert(a != NULL);
   assert(b != NULL);
-  assert(isIntZero(b) == 0);
+  assert(OBIntIsZero(b) == 0);
 
-  seed = createIntWithInt(0);
+  seed = OBIntCreate(0);
   result = reduceUnsignedInts(a, b, seed, 0);
   result->sign = a->sign;
   OBRelease((OBObjType *)seed);
@@ -333,15 +333,15 @@ OBInt * modInts(const OBInt *a, const OBInt *b){
 }
 
 
-OBInt * modIntWithPrim(const OBInt *a, int64_t b){
+OBInt * OBIntModPrimitive(const OBInt *a, int64_t b){
 
   OBInt *wrapper, *result;
 
   assert(a != NULL);
   assert(b != 0);
 
-  wrapper = createIntWithInt(b);
-  result = modInts(a, wrapper);
+  wrapper = OBIntCreate(b);
+  result = OBIntMod(a, wrapper);
   OBRelease((OBObjType *)wrapper);
 
   return result;
@@ -468,7 +468,7 @@ void displayInt(OBTypeRef to_print){
   assert(to_print);
   assert(OBObjIsOfClass(to_print, "OBInt"));
 
-  str = stringFromInt(instance);
+  str = OBIntGetStringValue(instance);
   fprintf(stderr, "Value:\n  %s\n", getCString(str));
   
   OBRelease((OBObjType *)str);
@@ -529,7 +529,7 @@ OBInt * subtractUnsignedInts(const OBInt *a, const OBInt *b){
   uint64_t i, a_most_sig, b_most_sig;
   OBInt *result;
 
-  result = copyInt(a);
+  result = OBIntCopy(a);
 
   a_most_sig = mostSig(a);
   b_most_sig = mostSig(b);
@@ -572,7 +572,7 @@ OBInt * multiplyUnsignedInts(const OBInt *a, const OBInt *b){
 
   /* base case, a and b are single digits */
   if(large_most_sig + small_most_sig < int64_max_digits)
-    return createIntWithInt(unsignedValue(a) * unsignedValue(b));
+    return OBIntCreate(unsignedValue(a) * unsignedValue(b));
 
   split_point = large_most_sig/2+1;
   splitInt(a, split_point, &x1, &x0);
@@ -636,13 +636,13 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
 
     if(quotient){
       result_val = a_val/b_val;
-      partial = createIntWithInt(result_val);
-      result = addInts(approx, partial);
+      partial = OBIntCreate(result_val);
+      result = OBIntAdd(approx, partial);
       OBRelease((OBObjType *)partial);
     }
     else{
       result_val = a_val%b_val;
-      result = createIntWithInt(result_val);
+      result = OBIntCreate(result_val);
     }
 
     return result;
@@ -651,13 +651,13 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
   /* if a < b (so a/b = 0, a%b = a) */
   comp_val = compareMagnitudes(a, b);
   if(comp_val == OB_LESS_THAN){
-    if(quotient) return copyInt(approx);
-    else return copyInt(a);
+    if(quotient) return OBIntCopy(approx);
+    else return OBIntCopy(a);
   }
   /* if a == b (so a/b = 1, a%b = 0) */
   else if(comp_val == OB_EQUAL_TO){
-    if(quotient) return addIntAndPrim(approx,1);
-    else return createIntWithInt(0);
+    if(quotient) return OBIntAddPrimitive(approx,1);
+    else return OBIntCreate(0);
   }
 
   /* else recursive division approximation */
@@ -691,7 +691,7 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
 
   /* perform approximation division, shift into proper decimal place, and add
    * to approximation */
-  partial = createIntWithInt(a_val/b_val);
+  partial = OBIntCreate(a_val/b_val);
   shiftInt(partial, i-j);
   product = multiplyUnsignedInts(partial, b);
 
@@ -704,7 +704,7 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
     OBRelease((OBObjType *)product);
 
     b_val++; 
-    partial = createIntWithInt(a_val/b_val);
+    partial = OBIntCreate(a_val/b_val);
     shiftInt(partial, i-j);
     product = multiplyUnsignedInts(partial, b);
   }

--- a/src/classes/OBInt.c
+++ b/src/classes/OBInt.c
@@ -202,7 +202,7 @@ OBInt * addIntAndPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = addInts(a, wrapper);
-  release((obj *)wrapper);
+  release((OBObjType *)wrapper);
 
   return result;
 }
@@ -250,7 +250,7 @@ OBInt * subtractIntWithPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = subtractInts(a, wrapper);
-  release((obj *)wrapper);
+  release((OBObjType *)wrapper);
 
   return result;
 }
@@ -278,7 +278,7 @@ OBInt * multiplyIntAndPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = multiplyInts(a, wrapper);
-  release((obj *)wrapper);
+  release((OBObjType *)wrapper);
 
   return result;
 }
@@ -295,7 +295,7 @@ OBInt * divideInts(const OBInt *a, const OBInt *b){
   seed = createIntWithInt(0);
   result = reduceUnsignedInts(a, b, seed, 1);
   result->sign = a->sign * b->sign;
-  release((obj *)seed);
+  release((OBObjType *)seed);
 
   return result;
 }
@@ -310,7 +310,7 @@ OBInt * divideIntWithPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = divideInts(a, wrapper);
-  release((obj *)wrapper);
+  release((OBObjType *)wrapper);
 
   return result;
 }
@@ -327,7 +327,7 @@ OBInt * modInts(const OBInt *a, const OBInt *b){
   seed = createIntWithInt(0);
   result = reduceUnsignedInts(a, b, seed, 0);
   result->sign = a->sign;
-  release((obj *)seed);
+  release((OBObjType *)seed);
 
   return result;
 }
@@ -342,7 +342,7 @@ OBInt * modIntWithPrim(const OBInt *a, int64_t b){
 
   wrapper = createIntWithInt(b);
   result = modInts(a, wrapper);
-  release((obj *)wrapper);
+  release((OBObjType *)wrapper);
 
   return result;
 }
@@ -359,7 +359,7 @@ OBInt * createDefaultInt(uint64_t num_digits){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocInt, &hashInt, &compareInts, 
+  initBase((OBObjType *)new_instance, &deallocInt, &hashInt, &compareInts, 
            &displayInt, classname);
 
   new_instance->sign = 1; /* positive by default */
@@ -374,7 +374,7 @@ OBInt * createDefaultInt(uint64_t num_digits){
 }
 
 
-obhash_t hashInt(const obj *to_hash){
+obhash_t hashInt(const OBObjType *to_hash){
 
   static int8_t init = 0;
   static obhash_t seed = 0;
@@ -410,7 +410,7 @@ obhash_t hashInt(const obj *to_hash){
 }
 
 
-int8_t compareInts(const obj *a, const obj *b){
+int8_t compareInts(const OBObjType *a, const OBObjType *b){
   
   int8_t magnitude_comp;
   const OBInt *comp_a = (OBInt *)a;  
@@ -460,7 +460,7 @@ int8_t compareMagnitudes(const OBInt *a, const OBInt *b){
 }
 
 
-void displayInt(const obj *to_print){
+void displayInt(const OBObjType *to_print){
 
   OBString *str;
   const OBInt *instance = (OBInt *)to_print;
@@ -471,13 +471,13 @@ void displayInt(const obj *to_print){
   str = stringFromInt(instance);
   fprintf(stderr, "Value:\n  %s\n", getCString(str));
   
-  release((obj *)str);
+  release((OBObjType *)str);
 
   return;
 }
 
 
-void deallocInt(obj *to_dealloc){
+void deallocInt(OBObjType *to_dealloc){
 
   /* cast generic obj to OBInt */
   OBInt *instance = (OBInt *)to_dealloc;
@@ -585,29 +585,29 @@ OBInt * multiplyUnsignedInts(const OBInt *a, const OBInt *b){
   z1b = addUnsignedInts(y1, y0);
   z1c = multiplyUnsignedInts(z1a, z1b);
 
-  release((obj *)x0);
-  release((obj *)x1);
-  release((obj *)y0);
-  release((obj *)y1);
-  release((obj *)z1a);
-  release((obj *)z1b);
+  release((OBObjType *)x0);
+  release((OBObjType *)x1);
+  release((OBObjType *)y0);
+  release((OBObjType *)y1);
+  release((OBObjType *)z1a);
+  release((OBObjType *)z1b);
 
   z1d = subtractUnsignedInts(z1c, z2);
-  release((obj *)z1c);
+  release((OBObjType *)z1c);
   z1 = subtractUnsignedInts(z1d, z0);
-  release((obj *)z1d);
+  release((OBObjType *)z1d);
 
   shiftInt(z2, 2*split_point);
   shiftInt(z1, split_point);
   partial_result = addUnsignedInts(z2, z1);
 
-  release((obj *) z2);
-  release((obj *) z1);
+  release((OBObjType *) z2);
+  release((OBObjType *) z1);
 
   result = addUnsignedInts(partial_result, z0);
   
-  release((obj *) partial_result);
-  release((obj *) z0);
+  release((OBObjType *) partial_result);
+  release((OBObjType *) z0);
 
   return result;
 }
@@ -638,7 +638,7 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
       result_val = a_val/b_val;
       partial = createIntWithInt(result_val);
       result = addInts(approx, partial);
-      release((obj *)partial);
+      release((OBObjType *)partial);
     }
     else{
       result_val = a_val%b_val;
@@ -700,8 +700,8 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
   /* if approximation is too great then increment b_val to account for remaining
    * portion of b that is causing over approximation */
   if(comp_val == OB_GREATER_THAN){
-    release((obj *)partial);
-    release((obj *)product);
+    release((OBObjType *)partial);
+    release((OBObjType *)product);
 
     b_val++; 
     partial = createIntWithInt(a_val/b_val);
@@ -710,14 +710,14 @@ OBInt * reduceUnsignedInts(const OBInt *a, const OBInt *b, const OBInt *approx,
   }
 
   new_dividend = subtractUnsignedInts(a, product);
-  release((obj *)product);
+  release((OBObjType *)product);
   new_approx = addUnsignedInts(approx, partial);
-  release((obj *)partial);
+  release((OBObjType *)partial);
 
   result = reduceUnsignedInts(new_dividend, b, new_approx, quotient);
 
-  release((obj *)new_approx);
-  release((obj *)new_dividend);
+  release((OBObjType *)new_approx);
+  release((OBObjType *)new_dividend);
 
   return result;
 }

--- a/src/classes/OBMap.c
+++ b/src/classes/OBMap.c
@@ -89,10 +89,10 @@ OBMap * copyMap(const OBMap *to_copy){
     do{
        mp = copyMapPair((OBMapPair *)objAtDequeIt(to_copy->pairs, it));
        addDequeTail(copy->pairs, (OBObjType *)mp);
-       release((OBObjType *)mp);
+       OBRelease((OBObjType *)mp);
     }while(iterateDequeNext(to_copy->pairs, it));
   }
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   rehashMap(copy); /* cannot grab to_copy->hash_table directly, stored iterators
                       must point to values within copy, not to copy */
@@ -126,11 +126,11 @@ void addToMap(OBMap *m, OBObjType *key, OBObjType *value){
 
   mp = createMapPair(key, value);
   addDequeTail(m->pairs, (OBObjType *)mp);
-  release((OBObjType *)mp); /* map deque has only reference to mp */
+  OBRelease((OBObjType *)mp); /* map deque has only reference to mp */
 
   assert(it = getDequeTailIt(m->pairs));
   addToHashTable(m, it);
-  release((OBObjType *)it); /* map vector hash only reference to it */
+  OBRelease((OBObjType *)it); /* map vector hash only reference to it */
   
   return; 
 }
@@ -179,7 +179,7 @@ void rehashMap(OBMap *m){
 
   assert(m);
 
-  release((OBObjType *)m->hash_table);
+  OBRelease((OBObjType *)m->hash_table);
   m->hash_table = createVector(MAP_CAPACITIES[m->cap_idx]);
 
   it = getDequeHeadIt(m->pairs);
@@ -188,10 +188,10 @@ void rehashMap(OBMap *m){
   do{
     it_copy = copyDequeIterator(it);
     addToHashTable(m, it_copy);
-    release((OBObjType *)it_copy);
+    OBRelease((OBObjType *)it_copy);
   }while(iterateDequeNext(m->pairs, it));
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   return;
 }
@@ -201,8 +201,8 @@ void clearMap(OBMap *m){
 
   assert(m);
 
-  release((OBObjType *)m->hash_table);
-  release((OBObjType *)m->pairs);
+  OBRelease((OBObjType *)m->hash_table);
+  OBRelease((OBObjType *)m->pairs);
 
   m->hash_table = createVector(MAP_CAPACITIES[m->cap_idx]);
   m->pairs = createDeque();
@@ -218,12 +218,12 @@ OBMapPair * createMapPair(OBObjType *key, OBObjType *value){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocMapPair, &hashMapPair, NULL, 
+  OBInitBase((OBObjType *)new_instance, &deallocMapPair, &hashMapPair, NULL, 
            &displayMapPair, classname);
 
-  retain(key);
+  OBRetain(key);
   new_instance->key = key;
-  retain(value);
+  OBRetain(value);
   new_instance->value = value;
 
   return new_instance;
@@ -240,8 +240,8 @@ void replaceMapPairValue(OBMapPair *mp, OBObjType *value){
 
   assert(mp);
   
-  retain(value);
-  release(mp->value);
+  OBRetain(value);
+  OBRelease(mp->value);
   mp->value = value;
   return;
 }
@@ -298,8 +298,8 @@ void deallocMapPair(OBObjType *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBMapPair"));
 
-  release((OBObjType *)instance->key);
-  release((OBObjType *)instance->value);
+  OBRelease((OBObjType *)instance->key);
+  OBRelease((OBObjType *)instance->value);
 
   return;
 }
@@ -315,7 +315,7 @@ OBMap * createDefaultMap(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocMap, &hashMap,
+  OBInitBase((OBObjType *)new_instance, &deallocMap, &hashMap,
            &compareMaps, &displayMap, classname);
 
   new_instance->hash_table = NULL;
@@ -355,7 +355,7 @@ obhash_t hashMap(const OBObjType *to_hash){
     value += hash(objAtDequeIt(instance->pairs, it));
   }while(iterateDequeNext(instance->pairs, it));
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   value += value << 3;
   value ^= value >> 11;
@@ -396,7 +396,7 @@ void displayMap(const OBObjType *to_print){
 
   fprintf(stderr, "  [map end]\n");
 
-  release((OBObjType *)it);
+  OBRelease((OBObjType *)it);
 
   return;
 }
@@ -410,8 +410,8 @@ void deallocMap(OBObjType *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBMap"));
 
-  release((OBObjType *)instance->hash_table);
-  release((OBObjType *)instance->pairs);
+  OBRelease((OBObjType *)instance->hash_table);
+  OBRelease((OBObjType *)instance->pairs);
 
   return;
 }

--- a/src/classes/OBMap.c
+++ b/src/classes/OBMap.c
@@ -88,11 +88,11 @@ OBMap * copyMap(const OBMap *to_copy){
   if(it){
     do{
        mp = copyMapPair((OBMapPair *)objAtDequeIt(to_copy->pairs, it));
-       addDequeTail(copy->pairs, (obj *)mp);
-       release((obj *)mp);
+       addDequeTail(copy->pairs, (OBObjType *)mp);
+       release((OBObjType *)mp);
     }while(iterateDequeNext(to_copy->pairs, it));
   }
-  release((obj *)it);
+  release((OBObjType *)it);
 
   rehashMap(copy); /* cannot grab to_copy->hash_table directly, stored iterators
                       must point to values within copy, not to copy */
@@ -101,7 +101,7 @@ OBMap * copyMap(const OBMap *to_copy){
 }
 
 
-void addToMap(OBMap *m, obj *key, obj *value){
+void addToMap(OBMap *m, OBObjType *key, OBObjType *value){
 
   OBMapPair *mp;
   OBDequeIterator *it;
@@ -125,18 +125,18 @@ void addToMap(OBMap *m, obj *key, obj *value){
     increaseMapSize(m);
 
   mp = createMapPair(key, value);
-  addDequeTail(m->pairs, (obj *)mp);
-  release((obj *)mp); /* map deque has only reference to mp */
+  addDequeTail(m->pairs, (OBObjType *)mp);
+  release((OBObjType *)mp); /* map deque has only reference to mp */
 
   assert(it = getDequeTailIt(m->pairs));
   addToHashTable(m, it);
-  release((obj *)it); /* map vector hash only reference to it */
+  release((OBObjType *)it); /* map vector hash only reference to it */
   
   return; 
 }
 
 
-obj * lookupMapKey(const OBMap *m, const obj *key){
+OBObjType * lookupMapKey(const OBMap *m, const OBObjType *key){
 
   OBDequeIterator *it;
   OBMapPair *mp;
@@ -154,7 +154,7 @@ obj * lookupMapKey(const OBMap *m, const obj *key){
 }
 
   
-void removeMapKey(OBMap *m, obj *key){
+void removeMapKey(OBMap *m, OBObjType *key){
 
   OBDequeIterator *it;
   obhash_t hash_value;
@@ -179,7 +179,7 @@ void rehashMap(OBMap *m){
 
   assert(m);
 
-  release((obj *)m->hash_table);
+  release((OBObjType *)m->hash_table);
   m->hash_table = createVector(MAP_CAPACITIES[m->cap_idx]);
 
   it = getDequeHeadIt(m->pairs);
@@ -188,10 +188,10 @@ void rehashMap(OBMap *m){
   do{
     it_copy = copyDequeIterator(it);
     addToHashTable(m, it_copy);
-    release((obj *)it_copy);
+    release((OBObjType *)it_copy);
   }while(iterateDequeNext(m->pairs, it));
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   return;
 }
@@ -201,8 +201,8 @@ void clearMap(OBMap *m){
 
   assert(m);
 
-  release((obj *)m->hash_table);
-  release((obj *)m->pairs);
+  release((OBObjType *)m->hash_table);
+  release((OBObjType *)m->pairs);
 
   m->hash_table = createVector(MAP_CAPACITIES[m->cap_idx]);
   m->pairs = createDeque();
@@ -211,14 +211,14 @@ void clearMap(OBMap *m){
 
 /* OBMapPair PRIVATE METHODS */
 
-OBMapPair * createMapPair(obj *key, obj *value){
+OBMapPair * createMapPair(OBObjType *key, OBObjType *value){
 
   static const char classname[] = "OBMapPair";
   OBMapPair *new_instance = malloc(sizeof(OBMapPair));
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocMapPair, &hashMapPair, NULL, 
+  initBase((OBObjType *)new_instance, &deallocMapPair, &hashMapPair, NULL, 
            &displayMapPair, classname);
 
   retain(key);
@@ -236,7 +236,7 @@ OBMapPair * copyMapPair(OBMapPair *mp){
 }
 
 
-void replaceMapPairValue(OBMapPair *mp, obj *value){
+void replaceMapPairValue(OBMapPair *mp, OBObjType *value){
 
   assert(mp);
   
@@ -246,7 +246,7 @@ void replaceMapPairValue(OBMapPair *mp, obj *value){
   return;
 }
 
-obhash_t hashMapPair(const obj *to_hash){
+obhash_t hashMapPair(const OBObjType *to_hash){
 
   static int8_t init = 0;
   static obhash_t seed = 0;
@@ -275,7 +275,7 @@ obhash_t hashMapPair(const obj *to_hash){
   return value;
 }
 
-void displayMapPair(const obj *to_print){
+void displayMapPair(const OBObjType *to_print){
 
   OBMapPair *mp = (OBMapPair *)to_print;
 
@@ -290,7 +290,7 @@ void displayMapPair(const obj *to_print){
 }
 
 
-void deallocMapPair(obj *to_dealloc){
+void deallocMapPair(OBObjType *to_dealloc){
 
   /* cast generic obj to OBMap */
   OBMapPair *instance = (OBMapPair *)to_dealloc;
@@ -298,8 +298,8 @@ void deallocMapPair(obj *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBMapPair"));
 
-  release((obj *)instance->key);
-  release((obj *)instance->value);
+  release((OBObjType *)instance->key);
+  release((OBObjType *)instance->value);
 
   return;
 }
@@ -315,7 +315,7 @@ OBMap * createDefaultMap(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocMap, &hashMap,
+  initBase((OBObjType *)new_instance, &deallocMap, &hashMap,
            &compareMaps, &displayMap, classname);
 
   new_instance->hash_table = NULL;
@@ -327,7 +327,7 @@ OBMap * createDefaultMap(void){
 }
 
 
-obhash_t hashMap(const obj *to_hash){
+obhash_t hashMap(const OBObjType *to_hash){
 
   static int8_t init = 0;
   static obhash_t seed = 0;
@@ -355,7 +355,7 @@ obhash_t hashMap(const obj *to_hash){
     value += hash(objAtDequeIt(instance->pairs, it));
   }while(iterateDequeNext(instance->pairs, it));
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   value += value << 3;
   value ^= value >> 11;
@@ -365,7 +365,7 @@ obhash_t hashMap(const obj *to_hash){
 }
 
 
-int8_t compareMaps(const obj *a, const obj *b){
+int8_t compareMaps(const OBObjType *a, const OBObjType *b){
   
   assert(a);
   assert(b);
@@ -377,7 +377,7 @@ int8_t compareMaps(const obj *a, const obj *b){
 }
 
 
-void displayMap(const obj *to_print){
+void displayMap(const OBObjType *to_print){
   
   OBMap *m = (OBMap *)to_print;
   OBDequeIterator *it;
@@ -396,13 +396,13 @@ void displayMap(const obj *to_print){
 
   fprintf(stderr, "  [map end]\n");
 
-  release((obj *)it);
+  release((OBObjType *)it);
 
   return;
 }
 
 
-void deallocMap(obj *to_dealloc){
+void deallocMap(OBObjType *to_dealloc){
 
   /* cast generic obj to OBMap */
   OBMap *instance = (OBMap *)to_dealloc;
@@ -410,8 +410,8 @@ void deallocMap(obj *to_dealloc){
   assert(to_dealloc);
   assert(objIsOfClass(to_dealloc, "OBMap"));
 
-  release((obj *)instance->hash_table);
-  release((obj *)instance->pairs);
+  release((OBObjType *)instance->hash_table);
+  release((OBObjType *)instance->pairs);
 
   return;
 }
@@ -449,11 +449,11 @@ void addToHashTable(OBMap *m, OBDequeIterator *it){
     m->collisions++;
   }
 
-  storeAtVectorIndex(m->hash_table, (obj *)it, hash_value);
+  storeAtVectorIndex(m->hash_table, (OBObjType *)it, hash_value);
 }
 
 
-obhash_t findKeyInHashTable(const OBMap *m, const obj *key){
+obhash_t findKeyInHashTable(const OBMap *m, const OBObjType *key){
   
   obhash_t hash_value, offset;
   OBMapPair *mp;

--- a/src/classes/OBMap.c
+++ b/src/classes/OBMap.c
@@ -87,7 +87,7 @@ OBMap * copyMap(const OBMap *to_copy){
   it = OBDequeGetHeadIterator(to_copy->pairs);
   if(it){
     do{
-       mp = copyMapPair((OBMapPair *)OBDequeObjAtIterator(to_copy->pairs, it));
+       mp = copyMapPair((OBMapPair *)OBDequeGetObjectAtIterator(to_copy->pairs, it));
        OBDequeAddTail(copy->pairs, (OBObjType *)mp);
        OBRelease((OBObjType *)mp);
     }while(OBDequeIterateNext(to_copy->pairs, it));
@@ -115,13 +115,13 @@ void addToMap(OBMap *m, OBObjType *key, OBObjType *value){
   /* If the key already exists in the map then overwrite the existing
    * value */
   if(it){
-    mp = (OBMapPair *)OBDequeObjAtIterator(m->pairs, it);
+    mp = (OBMapPair *)OBDequeGetObjectAtIterator(m->pairs, it);
     replaceMapPairValue(mp, value);
     return;
   }
 
   /* if add operation will overload the map then resize the map */
-  if((OBDequeLength(m->pairs)+1)/MAP_CAPACITIES[m->cap_idx] > MAX_LOAD_FACTOR)
+  if((OBDequeGetLength(m->pairs)+1)/MAP_CAPACITIES[m->cap_idx] > MAX_LOAD_FACTOR)
     increaseMapSize(m);
 
   mp = createMapPair(key, value);
@@ -149,7 +149,7 @@ OBObjType * lookupMapKey(const OBMap *m, const OBObjType *key){
 
   if(!it) return NULL;
 
-  mp = (OBMapPair *)OBDequeObjAtIterator(m->pairs, it);
+  mp = (OBMapPair *)OBDequeGetObjectAtIterator(m->pairs, it);
   return mp->value;
 }
 
@@ -166,7 +166,7 @@ void removeMapKey(OBMap *m, OBObjType *key){
 
   if(!it) return;
 
-  OBDequeRemoveAtIterator(m->pairs, it);
+  OBDequeRemoveObjectAtIterator(m->pairs, it);
   rehashMap(m);
 
   return;
@@ -352,7 +352,7 @@ obhash_t hashMap(OBTypeRef to_hash){
 
   /* perform commutative hash, so order of addition to table does not matter */
   do{
-    value += OBHash(OBDequeObjAtIterator(instance->pairs, it));
+    value += OBHash(OBDequeGetObjectAtIterator(instance->pairs, it));
   }while(OBDequeIterateNext(instance->pairs, it));
 
   OBRelease((OBObjType *)it);
@@ -391,7 +391,7 @@ void displayMap(OBTypeRef to_print){
   if(!it) return;
 
   do{
-    OBDisplay(OBDequeObjAtIterator(m->pairs, it));
+    OBDisplay(OBDequeGetObjectAtIterator(m->pairs, it));
   }while(OBDequeIterateNext(m->pairs, it));
 
   fprintf(stderr, "  [map end]\n");
@@ -439,7 +439,7 @@ void addToHashTable(OBMap *m, OBDequeIterator *it){
   assert(m);
   assert(it);
 
-  pair = (OBMapPair *)OBDequeObjAtIterator(m->pairs, it);
+  pair = (OBMapPair *)OBDequeGetObjectAtIterator(m->pairs, it);
   hash_value = OBHash(pair->key)%MAP_CAPACITIES[m->cap_idx];
   offset = 0;
 
@@ -463,7 +463,7 @@ obhash_t findKeyInHashTable(const OBMap *m, const OBObjType *key){
   offset = 0;
   
   while((it = (OBDequeIterator *)objAtVectorIndex(m->hash_table, hash_value))){
-    mp = (OBMapPair *)OBDequeObjAtIterator(m->pairs, it);
+    mp = (OBMapPair *)OBDequeGetObjectAtIterator(m->pairs, it);
     if(OBCompare(mp->key, key) == OB_EQUAL_TO)
       break;
     offset = collisionOffset(offset);

--- a/src/classes/OBMap.c
+++ b/src/classes/OBMap.c
@@ -246,7 +246,7 @@ void replaceMapPairValue(OBMapPair *mp, OBObjType *value){
   return;
 }
 
-obhash_t hashMapPair(const OBObjType *to_hash){
+obhash_t hashMapPair(OBTypeRef to_hash){
 
   static int8_t init = 0;
   static obhash_t seed = 0;
@@ -255,7 +255,7 @@ obhash_t hashMapPair(const OBObjType *to_hash){
   OBMapPair *instance = (OBMapPair *)to_hash;
 
   assert(to_hash);
-  assert(objIsOfClass(to_hash, "OBMapPair"));
+  assert(OBObjIsOfClass(to_hash, "OBMapPair"));
 
   if(init == 0){
     srand(time(NULL));
@@ -265,8 +265,8 @@ obhash_t hashMapPair(const OBObjType *to_hash){
 
   value = seed;
 
-  value += hash(instance->key);
-  value += hash(instance->value);
+  value += OBHash(instance->key);
+  value += OBHash(instance->value);
 
   value += value << 3;
   value ^= value >> 11;
@@ -275,28 +275,28 @@ obhash_t hashMapPair(const OBObjType *to_hash){
   return value;
 }
 
-void displayMapPair(const OBObjType *to_print){
+void displayMapPair(OBTypeRef to_print){
 
   OBMapPair *mp = (OBMapPair *)to_print;
 
   assert(to_print != NULL);
-  assert(objIsOfClass(to_print, "OBMapPair"));
+  assert(OBObjIsOfClass(to_print, "OBMapPair"));
   
   fprintf(stderr, "  [key]\n");
-  display(mp->key);
+  OBDisplay(mp->key);
   fprintf(stderr, "  [value]\n");
-  display(mp->value);
+  OBDisplay(mp->value);
   return;
 }
 
 
-void deallocMapPair(OBObjType *to_dealloc){
+void deallocMapPair(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBMap */
   OBMapPair *instance = (OBMapPair *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBMapPair"));
+  assert(OBObjIsOfClass(to_dealloc, "OBMapPair"));
 
   OBRelease((OBObjType *)instance->key);
   OBRelease((OBObjType *)instance->value);
@@ -315,7 +315,7 @@ OBMap * createDefaultMap(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  OBInitBase((OBObjType *)new_instance, &deallocMap, &hashMap,
+  OBInitBase(new_instance, &deallocMap, &hashMap,
            &compareMaps, &displayMap, classname);
 
   new_instance->hash_table = NULL;
@@ -327,7 +327,7 @@ OBMap * createDefaultMap(void){
 }
 
 
-obhash_t hashMap(const OBObjType *to_hash){
+obhash_t hashMap(OBTypeRef to_hash){
 
   static int8_t init = 0;
   static obhash_t seed = 0;
@@ -337,7 +337,7 @@ obhash_t hashMap(const OBObjType *to_hash){
   OBMap *instance = (OBMap *)to_hash;
 
   assert(to_hash);
-  assert(objIsOfClass(to_hash, "OBMap"));
+  assert(OBObjIsOfClass(to_hash, "OBMap"));
 
   if(init == 0){
     srand(time(NULL));
@@ -352,7 +352,7 @@ obhash_t hashMap(const OBObjType *to_hash){
 
   /* perform commutative hash, so order of addition to table does not matter */
   do{
-    value += hash(objAtDequeIt(instance->pairs, it));
+    value += OBHash(objAtDequeIt(instance->pairs, it));
   }while(iterateDequeNext(instance->pairs, it));
 
   OBRelease((OBObjType *)it);
@@ -365,25 +365,25 @@ obhash_t hashMap(const OBObjType *to_hash){
 }
 
 
-int8_t compareMaps(const OBObjType *a, const OBObjType *b){
+int8_t compareMaps(OBTypeRef a, OBTypeRef b){
   
   assert(a);
   assert(b);
-  assert(objIsOfClass(a, "OBMap"));
-  assert(objIsOfClass(b, "OBMap"));
+  assert(OBObjIsOfClass(a, "OBMap"));
+  assert(OBObjIsOfClass(b, "OBMap"));
 
-  if(hash(a) == hash(b)) return OB_EQUAL_TO;
+  if(OBHash(a) == OBHash(b)) return OB_EQUAL_TO;
   return OB_NOT_EQUAL;
 }
 
 
-void displayMap(const OBObjType *to_print){
+void displayMap(OBTypeRef to_print){
   
   OBMap *m = (OBMap *)to_print;
   OBDequeIterator *it;
 
   assert(to_print != NULL);
-  assert(objIsOfClass(to_print, "OBMap"));
+  assert(OBObjIsOfClass(to_print, "OBMap"));
   fprintf(stderr, "OBMap with key-value pairs:\n");
 
   it = getDequeHeadIt(m->pairs);
@@ -391,7 +391,7 @@ void displayMap(const OBObjType *to_print){
   if(!it) return;
 
   do{
-    display(objAtDequeIt(m->pairs, it));
+    OBDisplay(objAtDequeIt(m->pairs, it));
   }while(iterateDequeNext(m->pairs, it));
 
   fprintf(stderr, "  [map end]\n");
@@ -402,13 +402,13 @@ void displayMap(const OBObjType *to_print){
 }
 
 
-void deallocMap(OBObjType *to_dealloc){
+void deallocMap(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBMap */
   OBMap *instance = (OBMap *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBMap"));
+  assert(OBObjIsOfClass(to_dealloc, "OBMap"));
 
   OBRelease((OBObjType *)instance->hash_table);
   OBRelease((OBObjType *)instance->pairs);
@@ -440,7 +440,7 @@ void addToHashTable(OBMap *m, OBDequeIterator *it){
   assert(it);
 
   pair = (OBMapPair *)objAtDequeIt(m->pairs, it);
-  hash_value = hash(pair->key)%MAP_CAPACITIES[m->cap_idx];
+  hash_value = OBHash(pair->key)%MAP_CAPACITIES[m->cap_idx];
   offset = 0;
 
   while(objAtVectorIndex(m->hash_table, hash_value)){
@@ -459,12 +459,12 @@ obhash_t findKeyInHashTable(const OBMap *m, const OBObjType *key){
   OBMapPair *mp;
   OBDequeIterator *it;
 
-  hash_value = hash(key)%MAP_CAPACITIES[m->cap_idx];
+  hash_value = OBHash(key)%MAP_CAPACITIES[m->cap_idx];
   offset = 0;
   
   while((it = (OBDequeIterator *)objAtVectorIndex(m->hash_table, hash_value))){
     mp = (OBMapPair *)objAtDequeIt(m->pairs, it);
-    if(compare(mp->key, key) == OB_EQUAL_TO)
+    if(OBCompare(mp->key, key) == OB_EQUAL_TO)
       break;
     offset = collisionOffset(offset);
     hash_value = (hash_value+offset)%MAP_CAPACITIES[m->cap_idx];

--- a/src/classes/OBString.c
+++ b/src/classes/OBString.c
@@ -31,7 +31,7 @@ OBString *createString(const char *str){
 }
 
 
-OBString * copySubstring(const OBString *s, int64_t start, uint32_t length){
+OBString * copySubstring(const OBString *s, int64_t start, size_t length){
   
   OBString *instance;
 
@@ -53,7 +53,7 @@ OBString * copySubstring(const OBString *s, int64_t start, uint32_t length){
   if(start+length > s->length) length = s->length - start;
 
   /* if specified range contains no characters return an "empty" string */
-  if(start > s->length || start+length < 0 || s->length == 0 || length <= 0)
+  if(start > s->length || start+(long)length < 0 || s->length == 0 || length <= 0)
     return instance;
 
   instance->length = length;
@@ -67,7 +67,7 @@ OBString * copySubstring(const OBString *s, int64_t start, uint32_t length){
 }
 
 
-uint32_t stringLength(const OBString *s){
+size_t stringLength(const OBString *s){
   assert(s);  
   return s->length;
 }
@@ -116,8 +116,8 @@ OBVector * splitString(const OBString *s, const char *delim){
   OBVector *tokens;
   OBString *copy, *substring;
   char *marker;
-  uint32_t i, delim_len, substrs;
-
+  uint32_t i, substrs;
+  size_t delim_len;
 
   assert(s);
   assert(delim);
@@ -154,7 +154,7 @@ OBVector * splitString(const OBString *s, const char *delim){
 
 uint8_t findSubstring(const OBString *s, const char *substring){
 
-  uint32_t sublen;
+  size_t sublen;
   char *marker;
 
   assert(s);
@@ -225,7 +225,7 @@ OBString * createDefaultString(void){
 }
 
 
-obhash_t hashString(const OBObjType *to_hash){
+obhash_t hashString(OBTypeRef to_hash){
   
   static int8_t init = 0;
   static obhash_t seed;
@@ -235,7 +235,7 @@ obhash_t hashString(const OBObjType *to_hash){
   char *pos;
 
   assert(to_hash);
-  assert(objIsOfClass(to_hash, "OBString"));
+  assert(OBObjIsOfClass(to_hash, "OBString"));
 
   if(init == 0){
     srand(time(NULL));
@@ -260,7 +260,7 @@ obhash_t hashString(const OBObjType *to_hash){
 }
 
 
-int8_t compareStrings(const OBObjType *a, const OBObjType *b){
+int8_t compareStrings(OBTypeRef a, OBTypeRef b){
   
   uint32_t i;
   const OBString *comp_a = (OBString *)a;  
@@ -268,8 +268,8 @@ int8_t compareStrings(const OBObjType *a, const OBObjType *b){
 
   assert(a);
   assert(b);
-  assert(objIsOfClass(a, "OBString"));
-  assert(objIsOfClass(b, "OBString"));
+  assert(OBObjIsOfClass(a, "OBString"));
+  assert(OBObjIsOfClass(b, "OBString"));
 
   /* compare string contents where both have characters */
   for(i=0; i<comp_a->length && i<comp_b->length; i++){
@@ -284,20 +284,20 @@ int8_t compareStrings(const OBObjType *a, const OBObjType *b){
 }
 
 
-void displayString(const OBObjType *str){
+void displayString(OBTypeRef str){
   assert(str != NULL);
-  assert(objIsOfClass(str, "OBString"));
+  assert(OBObjIsOfClass(str, "OBString"));
   fprintf(stderr, "OBString with Contents:\n  %s\n", ((OBString *)str)->str);
 }
 
 
-void deallocString(OBObjType *to_dealloc){
+void deallocString(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBString */
   OBString *instance = (OBString *)to_dealloc;
 
   assert(to_dealloc);
-  assert(objIsOfClass(to_dealloc, "OBString"));
+  assert(OBObjIsOfClass(to_dealloc, "OBString"));
 
   if(instance->str) free(instance->str);
 

--- a/src/classes/OBString.c
+++ b/src/classes/OBString.c
@@ -143,11 +143,11 @@ OBVector * splitString(const OBString *s, const char *delim){
     substring = createString(marker);
     marker += substring->length;
     storeAtVectorIndex(tokens, (OBObjType *)substring, substrs++);
-    release((OBObjType *)substring); /* only tokens vector needs a reference */
+    OBRelease((OBObjType *)substring); /* only tokens vector needs a reference */
     while(*marker == '\0' && marker < copy->str + copy->length) marker++;
   }
 
-  release((OBObjType *)copy);
+  OBRelease((OBObjType *)copy);
   return tokens;
 }
 
@@ -213,7 +213,7 @@ OBString * createDefaultString(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((OBObjType *)new_instance, &deallocString, &hashString, &compareStrings,
+  OBInitBase((OBObjType *)new_instance, &deallocString, &hashString, &compareStrings,
            &displayString, classname);
 
   new_instance->str = malloc(sizeof(char));

--- a/src/classes/OBString.c
+++ b/src/classes/OBString.c
@@ -142,12 +142,12 @@ OBVector * splitString(const OBString *s, const char *delim){
   while(marker < copy->str+copy->length){
     substring = createString(marker);
     marker += substring->length;
-    storeAtVectorIndex(tokens, (obj *)substring, substrs++);
-    release((obj *)substring); /* only tokens vector needs a reference */
+    storeAtVectorIndex(tokens, (OBObjType *)substring, substrs++);
+    release((OBObjType *)substring); /* only tokens vector needs a reference */
     while(*marker == '\0' && marker < copy->str + copy->length) marker++;
   }
 
-  release((obj *)copy);
+  release((OBObjType *)copy);
   return tokens;
 }
 
@@ -213,7 +213,7 @@ OBString * createDefaultString(void){
   assert(new_instance != NULL);
 
   /* initialize base class data */
-  initBase((obj *)new_instance, &deallocString, &hashString, &compareStrings,
+  initBase((OBObjType *)new_instance, &deallocString, &hashString, &compareStrings,
            &displayString, classname);
 
   new_instance->str = malloc(sizeof(char));
@@ -225,7 +225,7 @@ OBString * createDefaultString(void){
 }
 
 
-obhash_t hashString(const obj *to_hash){
+obhash_t hashString(const OBObjType *to_hash){
   
   static int8_t init = 0;
   static obhash_t seed;
@@ -260,7 +260,7 @@ obhash_t hashString(const obj *to_hash){
 }
 
 
-int8_t compareStrings(const obj *a, const obj *b){
+int8_t compareStrings(const OBObjType *a, const OBObjType *b){
   
   uint32_t i;
   const OBString *comp_a = (OBString *)a;  
@@ -284,14 +284,14 @@ int8_t compareStrings(const obj *a, const obj *b){
 }
 
 
-void displayString(const obj *str){
+void displayString(const OBObjType *str){
   assert(str != NULL);
   assert(objIsOfClass(str, "OBString"));
   fprintf(stderr, "OBString with Contents:\n  %s\n", ((OBString *)str)->str);
 }
 
 
-void deallocString(obj *to_dealloc){
+void deallocString(OBObjType *to_dealloc){
 
   /* cast generic obj to OBString */
   OBString *instance = (OBString *)to_dealloc;

--- a/src/classes/OBTest.c
+++ b/src/classes/OBTest.c
@@ -17,7 +17,7 @@ OBTest * createTest(uint32_t id){
   assert(new_instance != NULL);
 
   /*initialize reference counting base data*/
-  initBase((obj *)new_instance, &deallocTest, &hashTest, &compareTests,
+  initBase((OBObjType *)new_instance, &deallocTest, &hashTest, &compareTests,
            &displayTest, classname);
 
   new_instance->id = id;
@@ -32,12 +32,12 @@ uint32_t getTestID(OBTest *a){
 
 /* PRIVATE METHODS */
 
-obhash_t hashTest(const obj *to_hash){
+obhash_t hashTest(const OBObjType *to_hash){
   assert(to_hash);
   return (obhash_t)(((OBTest *)to_hash)->id);
 }
 
-int8_t compareTests(const obj *a, const obj *b){
+int8_t compareTests(const OBObjType *a, const OBObjType *b){
 
   assert(a != NULL);
   assert(b != NULL);
@@ -49,13 +49,13 @@ int8_t compareTests(const obj *a, const obj *b){
   return OB_LESS_THAN;
 }
 
-void displayTest(const obj *test){
+void displayTest(const OBObjType *test){
   assert(test != NULL);
   assert(objIsOfClass(test, "OBTest"));
   fprintf(stderr, "Test ID: %u\n", ((OBTest *)test)->id);
 }
 
-void deallocTest(obj *to_dealloc){
+void deallocTest(OBObjType *to_dealloc){
   assert(to_dealloc != NULL);
   return;
 }

--- a/src/classes/OBTest.c
+++ b/src/classes/OBTest.c
@@ -9,7 +9,7 @@
 
 /* PUBLIC METHODS */
 
-OBTest * createTest(uint32_t id){
+OBTest * OBTestCreate(uint32_t id){
 
   static const char classname[] = "OBTest";
 
@@ -17,27 +17,27 @@ OBTest * createTest(uint32_t id){
   assert(new_instance != NULL);
 
   /*initialize reference counting base data*/
-  OBInitBase((OBObjType *)new_instance, &deallocTest, &hashTest, &compareTests,
-           &displayTest, classname);
+  OBInitBase((OBObjType *)new_instance, &OBTestDealloc, &OBTestHash, &OBTestCompare,
+           &OBTestDisplay, classname);
 
   new_instance->id = id;
   return new_instance;
 }
 
 
-uint32_t getTestID(OBTest *a){
+uint32_t OBTestGetID(OBTest *a){
   assert(a != NULL);
   return a->id;
 }
 
 /* PRIVATE METHODS */
 
-obhash_t hashTest(OBTypeRef to_hash){
+obhash_t OBTestHash(OBTypeRef to_hash){
   assert(to_hash);
   return (obhash_t)(((OBTest *)to_hash)->id);
 }
 
-int8_t compareTests(OBTypeRef a, OBTypeRef b){
+int8_t OBTestCompare(OBTypeRef a, OBTypeRef b){
 
   assert(a != NULL);
   assert(b != NULL);
@@ -49,13 +49,13 @@ int8_t compareTests(OBTypeRef a, OBTypeRef b){
   return OB_LESS_THAN;
 }
 
-void displayTest(OBTypeRef test){
+void OBTestDisplay(OBTypeRef test){
   assert(test != NULL);
   assert(OBObjIsOfClass(test, "OBTest"));
   fprintf(stderr, "Test ID: %u\n", ((OBTest *)test)->id);
 }
 
-void deallocTest(OBTypeRef to_dealloc){
+void OBTestDealloc(OBTypeRef to_dealloc){
   assert(to_dealloc != NULL);
   return;
 }

--- a/src/classes/OBTest.c
+++ b/src/classes/OBTest.c
@@ -32,30 +32,30 @@ uint32_t getTestID(OBTest *a){
 
 /* PRIVATE METHODS */
 
-obhash_t hashTest(const OBObjType *to_hash){
+obhash_t hashTest(OBTypeRef to_hash){
   assert(to_hash);
   return (obhash_t)(((OBTest *)to_hash)->id);
 }
 
-int8_t compareTests(const OBObjType *a, const OBObjType *b){
+int8_t compareTests(OBTypeRef a, OBTypeRef b){
 
   assert(a != NULL);
   assert(b != NULL);
-  assert(objIsOfClass(a, "OBTest"));
-  assert(objIsOfClass(b, "OBTest"));
+  assert(OBObjIsOfClass(a, "OBTest"));
+  assert(OBObjIsOfClass(b, "OBTest"));
 
   if(((OBTest *)a)->id >((OBTest *)b)->id) return OB_GREATER_THAN;
   if(((OBTest *)a)->id == ((OBTest *)b)->id) return OB_EQUAL_TO;
   return OB_LESS_THAN;
 }
 
-void displayTest(const OBObjType *test){
+void displayTest(OBTypeRef test){
   assert(test != NULL);
-  assert(objIsOfClass(test, "OBTest"));
+  assert(OBObjIsOfClass(test, "OBTest"));
   fprintf(stderr, "Test ID: %u\n", ((OBTest *)test)->id);
 }
 
-void deallocTest(OBObjType *to_dealloc){
+void deallocTest(OBTypeRef to_dealloc){
   assert(to_dealloc != NULL);
   return;
 }

--- a/src/classes/OBTest.c
+++ b/src/classes/OBTest.c
@@ -17,7 +17,7 @@ OBTest * createTest(uint32_t id){
   assert(new_instance != NULL);
 
   /*initialize reference counting base data*/
-  initBase((OBObjType *)new_instance, &deallocTest, &hashTest, &compareTests,
+  OBInitBase((OBObjType *)new_instance, &deallocTest, &hashTest, &compareTests,
            &displayTest, classname);
 
   new_instance->id = id;

--- a/src/classes/OBVector.c
+++ b/src/classes/OBVector.c
@@ -9,7 +9,7 @@
 
 /* PUBLIC METHODS */
 
-OBVector * createVector(uint32_t initial_capacity){
+OBVector * OBVectorCreateWithCapacity(uint32_t initial_capacity){
 
   uint32_t i, new_cap;
 
@@ -17,14 +17,14 @@ OBVector * createVector(uint32_t initial_capacity){
   while(initial_capacity > new_cap) new_cap *= 2;
   if(new_cap > UINT32_MAX) new_cap = UINT32_MAX;
 
-  OBVector *new_instance = createDefaultVector(new_cap);
+  OBVector *new_instance = OBVectorCreateDefault(new_cap);
   for(i=0; i<new_cap; i++) new_instance->array[i] = NULL;
 
   return new_instance;
 }
 
 
-OBVector * copyVector(const OBVector *to_copy){
+OBVector * OBVectorCopy(const OBVector *to_copy){
 
   uint32_t i;
   OBVector *new_vec;
@@ -32,7 +32,7 @@ OBVector * copyVector(const OBVector *to_copy){
   /* if there is nothing to copy, do nothing */
   assert(to_copy);
 
-  new_vec = createDefaultVector(to_copy->capacity);
+  new_vec = OBVectorCreateDefault(to_copy->capacity);
   new_vec->length = to_copy->length;
 
   for(i=0; i<to_copy->capacity; i++){
@@ -44,13 +44,13 @@ OBVector * copyVector(const OBVector *to_copy){
 }
 
 
-uint32_t vectorLength(const OBVector *v){
+uint32_t OBVectorGetLength(const OBVector *v){
   assert(v != NULL);
   return v->length;
 }
 
 
-void storeAtVectorIndex(OBVector *v, OBObjType *to_store, int64_t index){
+void OBVectorStoreAtIndex(OBVector *v, OBTypeRef to_store, int64_t index){
 
   assert(v != NULL);
 
@@ -61,7 +61,7 @@ void storeAtVectorIndex(OBVector *v, OBObjType *to_store, int64_t index){
   assert(index >= 0); /* assert not negative indexing after offset */
 
   /* ensure vector can store element at index */
-  resizeVector(v, (uint32_t)index);
+  OBVectorResize(v, (uint32_t)index);
 
   OBRetain(to_store);
   OBRelease(v->array[index]);
@@ -75,7 +75,7 @@ void storeAtVectorIndex(OBVector *v, OBObjType *to_store, int64_t index){
 }
 
 
-OBObjType * objAtVectorIndex(const OBVector *v, int64_t index){
+OBTypeRef OBVectorObjectAtIndex(const OBVector *v, int64_t index){
 
   assert(v != NULL);
 
@@ -89,7 +89,7 @@ OBObjType * objAtVectorIndex(const OBVector *v, int64_t index){
 }
 
 
-void catVectors(OBVector *destination, OBVector *to_append){
+void OBVectorConcatenateVector(OBVector *destination, OBVector *to_append){
 
   uint64_t i;
 
@@ -99,7 +99,7 @@ void catVectors(OBVector *destination, OBVector *to_append){
   assert(destination->length + to_append->length >= destination->length);
  
   /* ensure vector can store all elements in to_append */
-  resizeVector(destination, destination->length + to_append->length - 1);
+  OBVectorResize(destination, destination->length + to_append->length - 1);
 
   /* copy contents of to_append */
   for(i=0; i<to_append->length; i++){
@@ -113,7 +113,7 @@ void catVectors(OBVector *destination, OBVector *to_append){
 }
 
 
-uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find){
+uint8_t OBVectorContains(const OBVector *v, OBTypeRef to_find){
 
   uint32_t i;
 
@@ -131,14 +131,14 @@ uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find){
 }
 
 
-void sortVector(OBVector *v, int8_t order){
-  sortVectorWithFunct(v, order, &OBCompare);
+void OBVectorSort(OBVector *v, int8_t order){
+  OBVectorSortWithFunction(v, order, &OBCompare);
 }
 
 
-void sortVectorWithFunct(OBVector *v, int8_t order, obcompare_fptr funct){
+void OBVectorSortWithFunction(OBVector *v, int8_t order, obcompare_fptr funct){
 
-  OBObjType **sorted;
+  OBTypeRef *sorted;
 
   assert(v != NULL);
   assert(funct != NULL);
@@ -154,7 +154,7 @@ void sortVectorWithFunct(OBVector *v, int8_t order, obcompare_fptr funct){
 }
 
 
-void clearVector(OBVector *v){
+void OBVectorClear(OBVector *v){
 
   uint32_t i;
 
@@ -173,7 +173,7 @@ void clearVector(OBVector *v){
 /* PRIVATE METHODS */
 
 
-OBVector * createDefaultVector(uint32_t initial_capacity){
+OBVector * OBVectorCreateDefault(uint32_t initial_capacity){
 
   static const char classname[] = "OBVector";
 
@@ -181,8 +181,8 @@ OBVector * createDefaultVector(uint32_t initial_capacity){
   assert(new_instance != NULL);
 
   /* initialize reference counting base data */
-  OBInitBase((OBObjType *)new_instance, &deallocVector, &hashVector, &compareVectors,
-           &displayVector, classname);
+  OBInitBase((OBObjType *)new_instance, &OBVectorDealloc, &OBVectorHash, &OBVectorCompare,
+           &OBVectorDisplay, classname);
 
   /* a vector with zero capacity cannot be created, create one with a capacity
    * of one */
@@ -200,11 +200,11 @@ OBVector * createDefaultVector(uint32_t initial_capacity){
 }
 
 
-void resizeVector(OBVector *v, uint32_t index){
+void OBVectorResize(OBVector *v, uint32_t index){
 
   uint32_t i;
   uint64_t new_cap;
-  OBObjType **array;
+  OBTypeRef *array;
 
   assert(index < UINT32_MAX);
 
@@ -229,12 +229,12 @@ void resizeVector(OBVector *v, uint32_t index){
 }
 
 
-OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t order,
+OBTypeRef * recursiveSortContents(OBTypeRef *to_sort, uint32_t size, int8_t order,
                              obcompare_fptr funct){
   
   uint32_t i,j, split;
-  OBObjType **left_sorted, **right_sorted;
-  OBObjType **sorted;
+  OBTypeRef *left_sorted, *right_sorted;
+  OBTypeRef *sorted;
 
    /* base case, if the vector is of size one, its sorted */
   if(size <= 1){
@@ -297,7 +297,7 @@ OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t or
 }
 
 
-obhash_t hashVector(OBTypeRef to_hash){
+obhash_t OBVectorHash(OBTypeRef to_hash){
 
   static int8_t init = 0;
   static obhash_t seed;
@@ -330,7 +330,7 @@ obhash_t hashVector(OBTypeRef to_hash){
 }
 
 
-int8_t compareVectors(OBTypeRef a, OBTypeRef b){
+int8_t OBVectorCompare(OBTypeRef a, OBTypeRef b){
 
   uint32_t i;
   const OBVector *comp_a = (OBVector *)a;
@@ -351,7 +351,7 @@ int8_t compareVectors(OBTypeRef a, OBTypeRef b){
 }
 
 
-void displayVector(OBTypeRef to_print){
+void OBVectorDisplay(OBTypeRef to_print){
 
   uint32_t i;
   OBVector *v = (OBVector *)to_print;
@@ -371,7 +371,7 @@ void displayVector(OBTypeRef to_print){
 
 
 
-void deallocVector(OBTypeRef to_dealloc){
+void OBVectorDealloc(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBVector */
   OBVector *instance = (OBVector *)to_dealloc;
@@ -379,7 +379,7 @@ void deallocVector(OBTypeRef to_dealloc){
   assert(instance != NULL);
   assert(OBObjIsOfClass(to_dealloc, "OBVector"));
 
-  clearVector(instance); /* release all objs contained in vector */
+  OBVectorClear(instance); /* release all objs contained in vector */
   free(instance->array);
 
   return;
@@ -388,7 +388,7 @@ void deallocVector(OBTypeRef to_dealloc){
 
 /* PRIVATE UTILITY METHODS */
 
-uint32_t findValidPrecursorIndex(OBObjType **array, uint32_t index){
+uint32_t findValidPrecursorIndex(OBTypeRef *array, uint32_t index){
   while(index < UINT32_MAX && !array[index]) index--;
   return index;
 }

--- a/src/classes/OBVector.c
+++ b/src/classes/OBVector.c
@@ -50,7 +50,7 @@ uint32_t vectorLength(const OBVector *v){
 }
 
 
-void storeAtVectorIndex(OBVector *v, obj *to_store, int64_t index){
+void storeAtVectorIndex(OBVector *v, OBObjType *to_store, int64_t index){
 
   assert(v != NULL);
 
@@ -75,7 +75,7 @@ void storeAtVectorIndex(OBVector *v, obj *to_store, int64_t index){
 }
 
 
-obj * objAtVectorIndex(const OBVector *v, int64_t index){
+OBObjType * objAtVectorIndex(const OBVector *v, int64_t index){
 
   assert(v != NULL);
 
@@ -103,7 +103,7 @@ void catVectors(OBVector *destination, OBVector *to_append){
 
   /* copy contents of to_append */
   for(i=0; i<to_append->length; i++){
-    retain((obj *)to_append->array[i]);
+    retain((OBObjType *)to_append->array[i]);
     destination->array[i+destination->length] = to_append->array[i];
   }
 
@@ -113,7 +113,7 @@ void catVectors(OBVector *destination, OBVector *to_append){
 }
 
 
-uint8_t findObjInVector(const OBVector *v, const obj *to_find){
+uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find){
 
   uint32_t i;
 
@@ -138,7 +138,7 @@ void sortVector(OBVector *v, int8_t order){
 
 void sortVectorWithFunct(OBVector *v, int8_t order, compare_fptr funct){
 
-  obj **sorted;
+  OBObjType **sorted;
 
   assert(v != NULL);
   assert(funct != NULL);
@@ -181,7 +181,7 @@ OBVector * createDefaultVector(uint32_t initial_capacity){
   assert(new_instance != NULL);
 
   /* initialize reference counting base data */
-  initBase((obj *)new_instance, &deallocVector, &hashVector, &compareVectors,
+  initBase((OBObjType *)new_instance, &deallocVector, &hashVector, &compareVectors,
            &displayVector, classname);
 
   /* a vector with zero capacity cannot be created, create one with a capacity
@@ -190,7 +190,7 @@ OBVector * createDefaultVector(uint32_t initial_capacity){
     initial_capacity = 1;
   }
 
-  new_instance->array = malloc(initial_capacity*sizeof(obj *));
+  new_instance->array = malloc(initial_capacity*sizeof(OBObjType *));
   assert(new_instance->array != NULL);
 
   new_instance->capacity = initial_capacity;
@@ -204,7 +204,7 @@ void resizeVector(OBVector *v, uint32_t index){
 
   uint32_t i;
   uint64_t new_cap;
-  obj **array;
+  OBObjType **array;
 
   assert(index < UINT32_MAX);
 
@@ -215,7 +215,7 @@ void resizeVector(OBVector *v, uint32_t index){
   while(index+1 > new_cap) new_cap *= 2;
   if(new_cap > UINT32_MAX) new_cap = UINT32_MAX;
 
-  array = malloc(new_cap*sizeof(obj *));
+  array = malloc(new_cap*sizeof(OBObjType *));
 
   assert(array != NULL);
   for(i=0; i<v->capacity; i++) array[i] = v->array[i];
@@ -229,16 +229,16 @@ void resizeVector(OBVector *v, uint32_t index){
 }
 
 
-obj ** recursiveSortContents(obj **to_sort, uint32_t size, int8_t order,
+OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t order,
                              compare_fptr funct){
   
   uint32_t i,j, split;
-  obj **left_sorted, **right_sorted;
-  obj **sorted;
+  OBObjType **left_sorted, **right_sorted;
+  OBObjType **sorted;
 
    /* base case, if the vector is of size one, its sorted */
   if(size <= 1){
-    sorted = malloc(sizeof(obj *)*size);
+    sorted = malloc(sizeof(OBObjType *)*size);
     assert(sorted != NULL);
     *sorted = *to_sort;
     return sorted;
@@ -251,7 +251,7 @@ obj ** recursiveSortContents(obj **to_sort, uint32_t size, int8_t order,
   right_sorted = recursiveSortContents(to_sort+split, size-split, 
                                        order, funct);
   
-  sorted = malloc(sizeof(obj *)*size);
+  sorted = malloc(sizeof(OBObjType *)*size);
   assert(sorted != NULL);
 
   /* merge sorted halves */
@@ -297,7 +297,7 @@ obj ** recursiveSortContents(obj **to_sort, uint32_t size, int8_t order,
 }
 
 
-obhash_t hashVector(const obj *to_hash){
+obhash_t hashVector(const OBObjType *to_hash){
 
   static int8_t init = 0;
   static obhash_t seed;
@@ -330,7 +330,7 @@ obhash_t hashVector(const obj *to_hash){
 }
 
 
-int8_t compareVectors(const obj *a, const obj *b){
+int8_t compareVectors(const OBObjType *a, const OBObjType *b){
 
   uint32_t i;
   const OBVector *comp_a = (OBVector *)a;
@@ -351,7 +351,7 @@ int8_t compareVectors(const obj *a, const obj *b){
 }
 
 
-void displayVector(const obj *to_print){
+void displayVector(const OBObjType *to_print){
 
   uint32_t i;
   OBVector *v = (OBVector *)to_print;
@@ -371,7 +371,7 @@ void displayVector(const obj *to_print){
 
 
 
-void deallocVector(obj *to_dealloc){
+void deallocVector(OBObjType *to_dealloc){
 
   /* cast generic obj to OBVector */
   OBVector *instance = (OBVector *)to_dealloc;
@@ -388,7 +388,7 @@ void deallocVector(obj *to_dealloc){
 
 /* PRIVATE UTILITY METHODS */
 
-uint32_t findValidPrecursorIndex(obj **array, uint32_t index){
+uint32_t findValidPrecursorIndex(OBObjType **array, uint32_t index){
   while(index < UINT32_MAX && !array[index]) index--;
   return index;
 }

--- a/src/classes/OBVector.c
+++ b/src/classes/OBVector.c
@@ -36,7 +36,7 @@ OBVector * copyVector(const OBVector *to_copy){
   new_vec->length = to_copy->length;
 
   for(i=0; i<to_copy->capacity; i++){
-    retain(to_copy->array[i]);
+    OBRetain(to_copy->array[i]);
     new_vec->array[i] = to_copy->array[i];
   }
 
@@ -63,8 +63,8 @@ void storeAtVectorIndex(OBVector *v, OBObjType *to_store, int64_t index){
   /* ensure vector can store element at index */
   resizeVector(v, (uint32_t)index);
 
-  retain(to_store);
-  release(v->array[index]);
+  OBRetain(to_store);
+  OBRelease(v->array[index]);
   v->array[index] = to_store;
 
   /* find vector length if modifying beyond known length */
@@ -103,7 +103,7 @@ void catVectors(OBVector *destination, OBVector *to_append){
 
   /* copy contents of to_append */
   for(i=0; i<to_append->length; i++){
-    retain((OBObjType *)to_append->array[i]);
+    OBRetain((OBObjType *)to_append->array[i]);
     destination->array[i+destination->length] = to_append->array[i];
   }
 
@@ -136,7 +136,7 @@ void sortVector(OBVector *v, int8_t order){
 }
 
 
-void sortVectorWithFunct(OBVector *v, int8_t order, compare_fptr funct){
+void sortVectorWithFunct(OBVector *v, int8_t order, obcompare_fptr funct){
 
   OBObjType **sorted;
 
@@ -161,7 +161,7 @@ void clearVector(OBVector *v){
   assert(v != NULL);
 
   for(i=0; i<v->capacity; i++){
-    release(v->array[i]);
+    OBRelease(v->array[i]);
   }
 
   v->length = 0;
@@ -181,7 +181,7 @@ OBVector * createDefaultVector(uint32_t initial_capacity){
   assert(new_instance != NULL);
 
   /* initialize reference counting base data */
-  initBase((OBObjType *)new_instance, &deallocVector, &hashVector, &compareVectors,
+  OBInitBase((OBObjType *)new_instance, &deallocVector, &hashVector, &compareVectors,
            &displayVector, classname);
 
   /* a vector with zero capacity cannot be created, create one with a capacity
@@ -230,7 +230,7 @@ void resizeVector(OBVector *v, uint32_t index){
 
 
 OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t order,
-                             compare_fptr funct){
+                             obcompare_fptr funct){
   
   uint32_t i,j, split;
   OBObjType **left_sorted, **right_sorted;

--- a/src/classes/OBVector.c
+++ b/src/classes/OBVector.c
@@ -69,7 +69,7 @@ void storeAtVectorIndex(OBVector *v, OBObjType *to_store, int64_t index){
 
   /* find vector length if modifying beyond known length */
   if(index+1 >= v->length) 
-    v->length = findValidPrecursorIndex(v->array, index) + 1;
+    v->length = findValidPrecursorIndex(v->array, (uint32_t)index) + 1;
 
   return;
 }
@@ -122,7 +122,7 @@ uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find){
 
   for(i=0; i<v->length; i++){
     /* if the object exists in the vector */
-    if(compare(to_find, v->array[i]) == OB_EQUAL_TO){
+    if(OBCompare(to_find, v->array[i]) == OB_EQUAL_TO){
       return 1;
     }
   }
@@ -132,7 +132,7 @@ uint8_t findObjInVector(const OBVector *v, const OBObjType *to_find){
 
 
 void sortVector(OBVector *v, int8_t order){
-  sortVectorWithFunct(v, order, &compare);
+  sortVectorWithFunct(v, order, &OBCompare);
 }
 
 
@@ -223,7 +223,7 @@ void resizeVector(OBVector *v, uint32_t index){
 
   free(v->array);
   v->array = array;
-  v->capacity = new_cap;
+  v->capacity = (uint32_t)new_cap;
 
   return;
 }
@@ -297,7 +297,7 @@ OBObjType ** recursiveSortContents(OBObjType **to_sort, uint32_t size, int8_t or
 }
 
 
-obhash_t hashVector(const OBObjType *to_hash){
+obhash_t hashVector(OBTypeRef to_hash){
 
   static int8_t init = 0;
   static obhash_t seed;
@@ -307,7 +307,7 @@ obhash_t hashVector(const OBObjType *to_hash){
   OBVector *instance = (OBVector *)to_hash;
 
   assert(to_hash);
-  assert(objIsOfClass(to_hash, "OBVector"));
+  assert(OBObjIsOfClass(to_hash, "OBVector"));
 
   if(init == 0){
     srand(time(NULL));
@@ -317,7 +317,7 @@ obhash_t hashVector(const OBObjType *to_hash){
   
   value = seed;
   for(i=0; i<instance->length; i++){
-    value += hash(instance->array[i]);
+    value += OBHash(instance->array[i]);
     value += value << 10;
     value ^= value >> 6;
   }
@@ -330,7 +330,7 @@ obhash_t hashVector(const OBObjType *to_hash){
 }
 
 
-int8_t compareVectors(const OBObjType *a, const OBObjType *b){
+int8_t compareVectors(OBTypeRef a, OBTypeRef b){
 
   uint32_t i;
   const OBVector *comp_a = (OBVector *)a;
@@ -338,31 +338,31 @@ int8_t compareVectors(const OBObjType *a, const OBObjType *b){
 
   assert(a);
   assert(b);
-  assert(objIsOfClass(a, "OBVector"));
-  assert(objIsOfClass(b, "OBVector"));
+  assert(OBObjIsOfClass(a, "OBVector"));
+  assert(OBObjIsOfClass(b, "OBVector"));
 
   if(comp_a->length != comp_b->length) return OB_NOT_EQUAL;
 
   for(i=0; i<comp_a->length; i++)
-    if(compare(comp_a->array[i], comp_b->array[i]) != OB_EQUAL_TO)
+    if(OBCompare(comp_a->array[i], comp_b->array[i]) != OB_EQUAL_TO)
       return OB_NOT_EQUAL;
 
   return OB_EQUAL_TO;
 }
 
 
-void displayVector(const OBObjType *to_print){
+void displayVector(OBTypeRef to_print){
 
   uint32_t i;
   OBVector *v = (OBVector *)to_print;
 
   assert(to_print != NULL);
-  assert(objIsOfClass(to_print, "OBVector"));
+  assert(OBObjIsOfClass(to_print, "OBVector"));
   fprintf(stderr, "OBVector with %u elements\n", v->length);
 
   for(i=0; i<v->length; i++){
     fprintf(stderr, "[index: %u]\n", i);
-    display(v->array[i]);
+    OBDisplay(v->array[i]);
     fprintf(stderr, "\n");
   }
 
@@ -371,13 +371,13 @@ void displayVector(const OBObjType *to_print){
 
 
 
-void deallocVector(OBObjType *to_dealloc){
+void deallocVector(OBTypeRef to_dealloc){
 
   /* cast generic obj to OBVector */
   OBVector *instance = (OBVector *)to_dealloc;
 
   assert(instance != NULL);
-  assert(objIsOfClass(to_dealloc, "OBVector"));
+  assert(OBObjIsOfClass(to_dealloc, "OBVector"));
 
   clearVector(instance); /* release all objs contained in vector */
   free(instance->array);

--- a/src/offbrand_stdlib.c
+++ b/src/offbrand_stdlib.c
@@ -7,10 +7,10 @@
 #include "../include/offbrand.h"
 #include "../include/private/obj_Private.h"
 
-void initBase(OBObjType *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
-              compare_fptr compare_funct, display_fptr display_funct,
+void OBInitBase(OBTypeRef tr_instance, obdealloc_fptr dealloc_funct, obhash_fptr hash_funct,
+              obcompare_fptr compare_funct, obdisplay_fptr display_funct,
               const char *classname){
-
+  OBObjType *instance = (OBObjType *)tr_instance;
   assert(classname != NULL);
 
   *instance = malloc(sizeof(struct OBObjStruct));
@@ -36,19 +36,19 @@ void initBase(OBObjType *instance, dealloc_fptr dealloc_funct, hash_fptr hash_fu
 }
 
 
-OBObjType * release(OBObjType *instance){
+OBTypeRef OBRelease(OBTypeRef instance){
 
   if(!instance) return NULL;
-
+  OBObjType *localInstance = (OBObjType *)instance;
   /* if no other part of the program references the instance, destroy it */
-  if(--((*instance)->references) <= 0){
+  if(--((*localInstance)->references) <= 0){
 
     /* call class specific memory cleanup, if it exists */
-    if((*instance)->dealloc)
-      (*instance)->dealloc(instance);
+    if((*localInstance)->dealloc)
+      (*localInstance)->dealloc(localInstance);
 
-    free((struct OBObjStruct *)*instance); /* free reference counted base */
-    free(instance); /* free the entire object */
+    free((struct OBObjStruct *)*localInstance); /* free reference counted base */
+    free(localInstance); /* free the entire object */
 
     return NULL;
   }
@@ -57,19 +57,20 @@ OBObjType * release(OBObjType *instance){
 }
 
 
-void retain(OBObjType *instance){
+OBTypeRef OBRetain(OBTypeRef instance){
 
-  if(!instance) return;
+  if(!instance) return NULL;
 
-  assert((*instance)->references < UINT32_MAX); /* reference count > UINT32_MAX
+  OBObjType *localInstance = (OBObjType *)instance;
+  assert((*localInstance)->references < UINT32_MAX); /* reference count > UINT32_MAX
                                                    cannot be handled by lib */
-  ++((*instance)->references);
+  ++((*localInstance)->references);
 
-  return;
+  return instance;
 }
 
 
-uint32_t referenceCount(OBObjType *instance){
+obref_count_t OBReferenceCount(OBObjType *instance){
   if(!instance) return 0;
   return (*instance)->references;
 }

--- a/src/offbrand_stdlib.c
+++ b/src/offbrand_stdlib.c
@@ -21,13 +21,13 @@ void OBInitBase(OBTypeRef tr_instance, obdealloc_fptr dealloc_funct, obhash_fptr
 
   (*instance)->dealloc = dealloc_funct;
 
-  if(hash_funct != &hash) (*instance)->hash = hash_funct;
+  if(hash_funct != &OBHash) (*instance)->hash = hash_funct;
   else (*instance)->hash = NULL;
 
-  if(compare_funct != &compare) (*instance)->compare = compare_funct;
+  if(compare_funct != &OBCompare) (*instance)->compare = compare_funct;
   else (*instance)->compare = NULL;
 
-  if(display_funct != &display) (*instance)->display = display_funct;
+  if(display_funct != &OBDisplay) (*instance)->display = display_funct;
   else (*instance)->display = NULL;
 
   (*instance)->classname = classname;
@@ -76,8 +76,10 @@ obref_count_t OBReferenceCount(OBObjType *instance){
 }
 
 
-uint8_t objIsOfClass(const OBObjType *a, const char *classname){
+uint8_t OBObjIsOfClass(OBTypeRef b, const char *classname){
 
+  OBObjType *a = (OBObjType *)b;
+  assert(classname);
   if(!a){
     if(strcmp(classname, "NULL") == 0) return 1;
     return 0;
@@ -87,16 +89,17 @@ uint8_t objIsOfClass(const OBObjType *a, const char *classname){
 }
 
 
-uint8_t sameClass(const OBObjType *a, const OBObjType *b){
+uint8_t OBObjectsHaveSameClass(OBTypeRef a, OBTypeRef b){
   /* if both NULL, both are of the "NULL" class */
   if(!a && !b) return 1;
   else if(!a || !b) return 0;
-  return objIsOfClass(a, (*b)->classname);
+  OBObjType *bb = (OBObjType *)b;
+  return OBObjIsOfClass(a, (*bb)->classname);
 }
 
 
-obhash_t hash(const OBObjType *to_hash){
-
+obhash_t OBHash(OBTypeRef tr_to_hash){
+  OBObjType *to_hash = (OBObjType *)tr_to_hash;
   obhash_t retval;
 
   if(!to_hash) return 0;
@@ -114,16 +117,16 @@ obhash_t hash(const OBObjType *to_hash){
 }
 
 
-int8_t compare(const OBObjType *a, const OBObjType *b){
+int8_t OBCompare(OBTypeRef a, OBTypeRef b){
 
   int8_t retval;
 
   if(a == NULL && b == NULL) return OB_EQUAL_TO;
   else if(a == NULL || b == NULL) return OB_NOT_EQUAL;
 
-
-  if(sameClass(a, b) && (*a)->compare != NULL)
-    retval = (*a)->compare(a, b);
+  OBObjType *aa = (OBObjType *)a;
+  if(OBObjectsHaveSameClass(a, b) && (*aa)->compare != NULL)
+    retval = (*aa)->compare(a, b);
   else if(a == b) retval = OB_EQUAL_TO;
   else retval = OB_NOT_EQUAL;
 
@@ -131,7 +134,8 @@ int8_t compare(const OBObjType *a, const OBObjType *b){
 }
 
 
-void display(const OBObjType *to_print){
+void OBDisplay(OBTypeRef tr_to_print){
+  OBObjType *to_print = (OBObjType *)tr_to_print;
   if(!to_print){
     fprintf(stderr, "NULL value\n");
     return;

--- a/src/offbrand_stdlib.c
+++ b/src/offbrand_stdlib.c
@@ -1,7 +1,7 @@
 /**
  * @file offbrand_stdlib.c
  * @brief Standard Library Implementation
- * @author theck
+ * @author theck, danhd123
  */
 
 #include "../include/offbrand.h"

--- a/src/offbrand_stdlib.c
+++ b/src/offbrand_stdlib.c
@@ -13,7 +13,7 @@ void initBase(obj *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
 
   assert(classname != NULL);
 
-  *instance = malloc(sizeof(struct obj_struct));
+  *instance = malloc(sizeof(struct OBObjStruct));
 
   assert((*instance) != NULL);
 
@@ -47,7 +47,7 @@ obj * release(obj *instance){
     if((*instance)->dealloc)
       (*instance)->dealloc(instance);
 
-    free((struct obj_struct *)*instance); /* free reference counted base */
+    free((struct OBObjStruct *)*instance); /* free reference counted base */
     free(instance); /* free the entire object */
 
     return NULL;

--- a/src/offbrand_stdlib.c
+++ b/src/offbrand_stdlib.c
@@ -7,7 +7,7 @@
 #include "../include/offbrand.h"
 #include "../include/private/obj_Private.h"
 
-void initBase(obj *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
+void initBase(OBObjType *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
               compare_fptr compare_funct, display_fptr display_funct,
               const char *classname){
 
@@ -36,7 +36,7 @@ void initBase(obj *instance, dealloc_fptr dealloc_funct, hash_fptr hash_funct,
 }
 
 
-obj * release(obj *instance){
+OBObjType * release(OBObjType *instance){
 
   if(!instance) return NULL;
 
@@ -57,7 +57,7 @@ obj * release(obj *instance){
 }
 
 
-void retain(obj *instance){
+void retain(OBObjType *instance){
 
   if(!instance) return;
 
@@ -69,13 +69,13 @@ void retain(obj *instance){
 }
 
 
-uint32_t referenceCount(obj *instance){
+uint32_t referenceCount(OBObjType *instance){
   if(!instance) return 0;
   return (*instance)->references;
 }
 
 
-uint8_t objIsOfClass(const obj *a, const char *classname){
+uint8_t objIsOfClass(const OBObjType *a, const char *classname){
 
   if(!a){
     if(strcmp(classname, "NULL") == 0) return 1;
@@ -86,7 +86,7 @@ uint8_t objIsOfClass(const obj *a, const char *classname){
 }
 
 
-uint8_t sameClass(const obj *a, const obj *b){
+uint8_t sameClass(const OBObjType *a, const OBObjType *b){
   /* if both NULL, both are of the "NULL" class */
   if(!a && !b) return 1;
   else if(!a || !b) return 0;
@@ -94,7 +94,7 @@ uint8_t sameClass(const obj *a, const obj *b){
 }
 
 
-obhash_t hash(const obj *to_hash){
+obhash_t hash(const OBObjType *to_hash){
 
   obhash_t retval;
 
@@ -113,7 +113,7 @@ obhash_t hash(const obj *to_hash){
 }
 
 
-int8_t compare(const obj *a, const obj *b){
+int8_t compare(const OBObjType *a, const OBObjType *b){
 
   int8_t retval;
 
@@ -130,7 +130,7 @@ int8_t compare(const obj *a, const obj *b){
 }
 
 
-void display(const obj *to_print){
+void display(const OBObjType *to_print){
   if(!to_print){
     fprintf(stderr, "NULL value\n");
     return;

--- a/src/tests/OBDeque_test.c
+++ b/src/tests/OBDeque_test.c
@@ -27,7 +27,7 @@ int main (){
 
   /* test the empty deque */
   assert(OBDequeIsEmpty(test_deque_a) != 0);
-  assert(OBDequeLength(test_deque_a) == 0);
+  assert(OBDequeGetLength(test_deque_a) == 0);
   assert(OBDequeGetHeadIterator(test_deque_a) == NULL);
   assert(OBDequeGetTailIterator(test_deque_a) == NULL);
 
@@ -35,18 +35,18 @@ int main (){
   OBDequeAddHead(test_deque_a, (OBObjType *)a);
 
   assert(OBDequeIsEmpty(test_deque_a) == 0);
-  assert(OBDequeLength(test_deque_a) == 1);
+  assert(OBDequeGetLength(test_deque_a) == 1);
   assert(OBReferenceCount((OBObjType *)a) == 2);
-  assert(getTestID((OBTest *)OBDequeFirstObject(test_deque_a)) == 1);
-  assert(getTestID((OBTest *)OBDequeLastObject(test_deque_a)) == 1);
+  assert(getTestID((OBTest *)OBDequeGetFirstObject(test_deque_a)) == 1);
+  assert(getTestID((OBTest *)OBDequeGetLastObject(test_deque_a)) == 1);
 
   head_it = OBDequeGetHeadIterator(test_deque_a);
   tail_it = OBDequeGetTailIterator(test_deque_a);
 
   assert(head_it != NULL);
   assert(tail_it != NULL);
-  assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, head_it)) == 1);
-  assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, tail_it)) == 1);
+  assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) == 1);
+  assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, tail_it)) == 1);
 
   assert(OBDequeContains(test_deque_a, (OBObjType *)a));
 
@@ -61,7 +61,7 @@ int main (){
 
 
   assert(OBDequeIsEmpty(test_deque_a) != 0);
-  assert(OBDequeLength(test_deque_a) == 0);
+  assert(OBDequeGetLength(test_deque_a) == 0);
   assert(OBDequeGetHeadIterator(test_deque_a) == NULL);
   assert(OBDequeGetTailIterator(test_deque_a) == NULL);
 
@@ -73,16 +73,16 @@ int main (){
   OBDequeAddTail(test_deque_a, (OBObjType *)e);
 
   assert(OBDequeIsEmpty(test_deque_a) == 0);
-  assert(OBDequeLength(test_deque_a) == 5);
+  assert(OBDequeGetLength(test_deque_a) == 5);
 
   /* test deque removal functions */
   head_it = OBDequeGetHeadIterator(test_deque_a);
-  OBDequeRemoveAtIterator(test_deque_a, head_it);
+  OBDequeRemoveObjectAtIterator(test_deque_a, head_it);
   OBRelease((OBObjType *)head_it);
 
   head_it = OBDequeGetHeadIterator(test_deque_a);
   do{
-    assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, head_it)) != 4);
+    assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) != 4);
   }while(OBDequeIterateNext(test_deque_a, head_it));
 
   OBRelease((OBObjType *)head_it);
@@ -96,14 +96,14 @@ int main (){
 
   OBDequeSort(test_deque_a, OB_LEAST_TO_GREATEST);
 
-  assert(OBDequeLength(test_deque_a) == 5);
+  assert(OBDequeGetLength(test_deque_a) == 5);
   assert(OBCompare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_NOT_EQUAL);
   assert(OBHash((OBObjType *)test_deque_a) !=  OBHash((OBObjType *)test_deque_b));
 
   i = 1;
   head_it = OBDequeGetHeadIterator(test_deque_a);
   do{
-    assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, head_it)) == i);
+    assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) == i);
     i++;
   }while(OBDequeIterateNext(test_deque_a, head_it));
 
@@ -115,7 +115,7 @@ int main (){
   joined_deque = OBDequeJoin(test_deque_a, test_deque_b);
   OBDequeSort(joined_deque, OB_GREATEST_TO_LEAST);
 
-  assert(OBDequeLength(joined_deque) == 10);
+  assert(OBDequeGetLength(joined_deque) == 10);
   assert(OBReferenceCount((OBObjType *)a) == 5); /* the joined deque has two references,
                                             as a is contained within twice */
   
@@ -136,7 +136,7 @@ int main (){
   
 
   for(i=0; i<10; i++){
-    assert(getTestID((OBTest *)OBDequeObjAtIterator(joined_deque, tail_it)) == i/2+1);
+    assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(joined_deque, tail_it)) == i/2+1);
     if(i != 9) assert(OBDequeIteratePrevious(joined_deque, tail_it));
   }
 
@@ -152,7 +152,7 @@ int main (){
   }
 
   assert(OBDequeIsEmpty(joined_deque) != 0);
-  assert(OBDequeLength(joined_deque) == 0);
+  assert(OBDequeGetLength(joined_deque) == 0);
   assert(OBReferenceCount((OBObjType *)a) == 1);
 
   OBRelease((OBObjType *)test_deque_a);

--- a/src/tests/OBDeque_test.c
+++ b/src/tests/OBDeque_test.c
@@ -32,11 +32,11 @@ int main (){
   assert(getDequeTailIt(test_deque_a) == NULL);
 
   /* test a deque with a single element */
-  addDequeHead(test_deque_a, (obj *)a);
+  addDequeHead(test_deque_a, (OBObjType *)a);
 
   assert(isDequeEmpty(test_deque_a) == 0);
   assert(dequeLength(test_deque_a) == 1);
-  assert(referenceCount((obj *)a) == 2);
+  assert(referenceCount((OBObjType *)a) == 2);
   assert(getTestID((OBTest *)objAtDequeHead(test_deque_a)) == 1);
   assert(getTestID((OBTest *)objAtDequeTail(test_deque_a)) == 1);
 
@@ -48,16 +48,16 @@ int main (){
   assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, head_it)) == 1);
   assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, tail_it)) == 1);
 
-  assert(findObjInDeque(test_deque_a, (obj *)a));
+  assert(findObjInDeque(test_deque_a, (OBObjType *)a));
 
   /* test removing the only element from the deque */
   removeDequeTail(test_deque_a);
 
   /* check that element is still referenced because of existing iterators */
-  assert(referenceCount((obj *)a) == 2);
-  release((obj *)head_it);
-  release((obj *)tail_it);
-  assert(referenceCount((obj *)a) == 1);
+  assert(referenceCount((OBObjType *)a) == 2);
+  release((OBObjType *)head_it);
+  release((OBObjType *)tail_it);
+  assert(referenceCount((OBObjType *)a) == 1);
 
 
   assert(isDequeEmpty(test_deque_a) != 0);
@@ -66,11 +66,11 @@ int main (){
   assert(getDequeTailIt(test_deque_a) == NULL);
 
   /* test deque with multiple elements */
-  addDequeTail(test_deque_a, (obj *)a);
-  addDequeHead(test_deque_a, (obj *)b);
-  addDequeTail(test_deque_a, (obj *)c);
-  addDequeHead(test_deque_a, (obj *)d);
-  addDequeTail(test_deque_a, (obj *)e);
+  addDequeTail(test_deque_a, (OBObjType *)a);
+  addDequeHead(test_deque_a, (OBObjType *)b);
+  addDequeTail(test_deque_a, (OBObjType *)c);
+  addDequeHead(test_deque_a, (OBObjType *)d);
+  addDequeTail(test_deque_a, (OBObjType *)e);
 
   assert(isDequeEmpty(test_deque_a) == 0);
   assert(dequeLength(test_deque_a) == 5);
@@ -78,27 +78,27 @@ int main (){
   /* test deque removal functions */
   head_it = getDequeHeadIt(test_deque_a);
   removeDequeAtIt(test_deque_a, head_it);
-  release((obj *)head_it);
+  release((OBObjType *)head_it);
 
   head_it = getDequeHeadIt(test_deque_a);
   do{
     assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, head_it)) != 4);
   }while(iterateDequeNext(test_deque_a, head_it));
 
-  release((obj *)head_it);
-  addDequeHead(test_deque_a, (obj *)d);
+  release((OBObjType *)head_it);
+  addDequeHead(test_deque_a, (OBObjType *)d);
 
   test_deque_b = copyDeque(test_deque_a);
 
-  assert(referenceCount((obj *)a) == 3);
-  assert(compare((obj *)test_deque_a, (obj *)test_deque_b) == OB_EQUAL_TO);
-  assert(hash((obj *)test_deque_a) ==  hash((obj *)test_deque_b));
+  assert(referenceCount((OBObjType *)a) == 3);
+  assert(compare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_EQUAL_TO);
+  assert(hash((OBObjType *)test_deque_a) ==  hash((OBObjType *)test_deque_b));
 
   sortDeque(test_deque_a, OB_LEAST_TO_GREATEST);
 
   assert(dequeLength(test_deque_a) == 5);
-  assert(compare((obj *)test_deque_a, (obj *)test_deque_b) == OB_NOT_EQUAL);
-  assert(hash((obj *)test_deque_a) !=  hash((obj *)test_deque_b));
+  assert(compare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_NOT_EQUAL);
+  assert(hash((OBObjType *)test_deque_a) !=  hash((OBObjType *)test_deque_b));
 
   i = 1;
   head_it = getDequeHeadIt(test_deque_a);
@@ -107,31 +107,31 @@ int main (){
     i++;
   }while(iterateDequeNext(test_deque_a, head_it));
 
-  release((obj *)head_it);
-  release((obj *)test_deque_a);
-  assert(referenceCount((obj *)a) == 2);
+  release((OBObjType *)head_it);
+  release((OBObjType *)test_deque_a);
+  assert(referenceCount((OBObjType *)a) == 2);
 
   test_deque_a = copyDeque(test_deque_b);
   joined_deque = joinDeques(test_deque_a, test_deque_b);
   sortDeque(joined_deque, OB_GREATEST_TO_LEAST);
 
   assert(dequeLength(joined_deque) == 10);
-  assert(referenceCount((obj *)a) == 5); /* the joined deque has two references,
+  assert(referenceCount((OBObjType *)a) == 5); /* the joined deque has two references,
                                             as a is contained within twice */
   
   tail_it = getDequeTailIt(joined_deque);
   removeDequeTail(joined_deque);
   assert(iterateDequePrev(joined_deque, tail_it) == 0);
   assert(iterateDequeNext(joined_deque, tail_it) == 0);
-  release((obj *)tail_it);
+  release((OBObjType *)tail_it);
 
   tail_it = getDequeTailIt(joined_deque);
-  addAtDequeIt(joined_deque, tail_it, (obj *)a);
-  release((obj *)tail_it);
+  addAtDequeIt(joined_deque, tail_it, (OBObjType *)a);
+  release((OBObjType *)tail_it);
 
   tail_it = getDequeTailIt(joined_deque);
   copy_it = copyDequeIterator(tail_it);
-  release((obj *)tail_it);
+  release((OBObjType *)tail_it);
   tail_it = copy_it;
   
 
@@ -142,7 +142,7 @@ int main (){
 
   assert(iterateDequePrev(joined_deque, tail_it) == 0);
 
-  release((obj *)tail_it);
+  release((OBObjType *)tail_it);
 
   clearDeque(test_deque_a);
   clearDeque(test_deque_b);
@@ -153,16 +153,16 @@ int main (){
 
   assert(isDequeEmpty(joined_deque) != 0);
   assert(dequeLength(joined_deque) == 0);
-  assert(referenceCount((obj *)a) == 1);
+  assert(referenceCount((OBObjType *)a) == 1);
 
-  release((obj *)test_deque_a);
-  release((obj *)test_deque_b);
-  release((obj *)joined_deque);
-  release((obj *)e);
-  release((obj *)d);
-  release((obj *)c);
-  release((obj *)b);
-  release((obj *)a);
+  release((OBObjType *)test_deque_a);
+  release((OBObjType *)test_deque_b);
+  release((OBObjType *)joined_deque);
+  release((OBObjType *)e);
+  release((OBObjType *)d);
+  release((OBObjType *)c);
+  release((OBObjType *)b);
+  release((OBObjType *)a);
 
   printf("OBDeque_test: TESTS PASSED\n");
   return 0;

--- a/src/tests/OBDeque_test.c
+++ b/src/tests/OBDeque_test.c
@@ -91,14 +91,14 @@ int main (){
   test_deque_b = copyDeque(test_deque_a);
 
   assert(OBReferenceCount((OBObjType *)a) == 3);
-  assert(compare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_EQUAL_TO);
-  assert(hash((OBObjType *)test_deque_a) ==  hash((OBObjType *)test_deque_b));
+  assert(OBCompare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_EQUAL_TO);
+  assert(OBHash((OBObjType *)test_deque_a) ==  OBHash((OBObjType *)test_deque_b));
 
   sortDeque(test_deque_a, OB_LEAST_TO_GREATEST);
 
   assert(dequeLength(test_deque_a) == 5);
-  assert(compare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_NOT_EQUAL);
-  assert(hash((OBObjType *)test_deque_a) !=  hash((OBObjType *)test_deque_b));
+  assert(OBCompare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_NOT_EQUAL);
+  assert(OBHash((OBObjType *)test_deque_a) !=  OBHash((OBObjType *)test_deque_b));
 
   i = 1;
   head_it = getDequeHeadIt(test_deque_a);

--- a/src/tests/OBDeque_test.c
+++ b/src/tests/OBDeque_test.c
@@ -18,11 +18,11 @@ int main (){
 
   /* create test objects */
   test_deque_a = OBDequeCreate();
-  a = createTest(1);
-  b = createTest(2);
-  c = createTest(3);
-  d = createTest(4);
-  e = createTest(5);
+  a = OBTestCreate(1);
+  b = OBTestCreate(2);
+  c = OBTestCreate(3);
+  d = OBTestCreate(4);
+  e = OBTestCreate(5);
 
 
   /* test the empty deque */
@@ -37,16 +37,16 @@ int main (){
   assert(OBDequeIsEmpty(test_deque_a) == 0);
   assert(OBDequeGetLength(test_deque_a) == 1);
   assert(OBReferenceCount((OBObjType *)a) == 2);
-  assert(getTestID((OBTest *)OBDequeGetFirstObject(test_deque_a)) == 1);
-  assert(getTestID((OBTest *)OBDequeGetLastObject(test_deque_a)) == 1);
+  assert(OBTestGetID((OBTest *)OBDequeGetFirstObject(test_deque_a)) == 1);
+  assert(OBTestGetID((OBTest *)OBDequeGetLastObject(test_deque_a)) == 1);
 
   head_it = OBDequeGetHeadIterator(test_deque_a);
   tail_it = OBDequeGetTailIterator(test_deque_a);
 
   assert(head_it != NULL);
   assert(tail_it != NULL);
-  assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) == 1);
-  assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, tail_it)) == 1);
+  assert(OBTestGetID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) == 1);
+  assert(OBTestGetID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, tail_it)) == 1);
 
   assert(OBDequeContains(test_deque_a, (OBObjType *)a));
 
@@ -82,7 +82,7 @@ int main (){
 
   head_it = OBDequeGetHeadIterator(test_deque_a);
   do{
-    assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) != 4);
+    assert(OBTestGetID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) != 4);
   }while(OBDequeIterateNext(test_deque_a, head_it));
 
   OBRelease((OBObjType *)head_it);
@@ -103,7 +103,7 @@ int main (){
   i = 1;
   head_it = OBDequeGetHeadIterator(test_deque_a);
   do{
-    assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) == i);
+    assert(OBTestGetID((OBTest *)OBDequeGetObjectAtIterator(test_deque_a, head_it)) == i);
     i++;
   }while(OBDequeIterateNext(test_deque_a, head_it));
 
@@ -136,7 +136,7 @@ int main (){
   
 
   for(i=0; i<10; i++){
-    assert(getTestID((OBTest *)OBDequeGetObjectAtIterator(joined_deque, tail_it)) == i/2+1);
+    assert(OBTestGetID((OBTest *)OBDequeGetObjectAtIterator(joined_deque, tail_it)) == i/2+1);
     if(i != 9) assert(OBDequeIteratePrevious(joined_deque, tail_it));
   }
 

--- a/src/tests/OBDeque_test.c
+++ b/src/tests/OBDeque_test.c
@@ -36,7 +36,7 @@ int main (){
 
   assert(isDequeEmpty(test_deque_a) == 0);
   assert(dequeLength(test_deque_a) == 1);
-  assert(referenceCount((OBObjType *)a) == 2);
+  assert(OBReferenceCount((OBObjType *)a) == 2);
   assert(getTestID((OBTest *)objAtDequeHead(test_deque_a)) == 1);
   assert(getTestID((OBTest *)objAtDequeTail(test_deque_a)) == 1);
 
@@ -54,10 +54,10 @@ int main (){
   removeDequeTail(test_deque_a);
 
   /* check that element is still referenced because of existing iterators */
-  assert(referenceCount((OBObjType *)a) == 2);
-  release((OBObjType *)head_it);
-  release((OBObjType *)tail_it);
-  assert(referenceCount((OBObjType *)a) == 1);
+  assert(OBReferenceCount((OBObjType *)a) == 2);
+  OBRelease((OBObjType *)head_it);
+  OBRelease((OBObjType *)tail_it);
+  assert(OBReferenceCount((OBObjType *)a) == 1);
 
 
   assert(isDequeEmpty(test_deque_a) != 0);
@@ -78,19 +78,19 @@ int main (){
   /* test deque removal functions */
   head_it = getDequeHeadIt(test_deque_a);
   removeDequeAtIt(test_deque_a, head_it);
-  release((OBObjType *)head_it);
+  OBRelease((OBObjType *)head_it);
 
   head_it = getDequeHeadIt(test_deque_a);
   do{
     assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, head_it)) != 4);
   }while(iterateDequeNext(test_deque_a, head_it));
 
-  release((OBObjType *)head_it);
+  OBRelease((OBObjType *)head_it);
   addDequeHead(test_deque_a, (OBObjType *)d);
 
   test_deque_b = copyDeque(test_deque_a);
 
-  assert(referenceCount((OBObjType *)a) == 3);
+  assert(OBReferenceCount((OBObjType *)a) == 3);
   assert(compare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_EQUAL_TO);
   assert(hash((OBObjType *)test_deque_a) ==  hash((OBObjType *)test_deque_b));
 
@@ -107,31 +107,31 @@ int main (){
     i++;
   }while(iterateDequeNext(test_deque_a, head_it));
 
-  release((OBObjType *)head_it);
-  release((OBObjType *)test_deque_a);
-  assert(referenceCount((OBObjType *)a) == 2);
+  OBRelease((OBObjType *)head_it);
+  OBRelease((OBObjType *)test_deque_a);
+  assert(OBReferenceCount((OBObjType *)a) == 2);
 
   test_deque_a = copyDeque(test_deque_b);
   joined_deque = joinDeques(test_deque_a, test_deque_b);
   sortDeque(joined_deque, OB_GREATEST_TO_LEAST);
 
   assert(dequeLength(joined_deque) == 10);
-  assert(referenceCount((OBObjType *)a) == 5); /* the joined deque has two references,
+  assert(OBReferenceCount((OBObjType *)a) == 5); /* the joined deque has two references,
                                             as a is contained within twice */
   
   tail_it = getDequeTailIt(joined_deque);
   removeDequeTail(joined_deque);
   assert(iterateDequePrev(joined_deque, tail_it) == 0);
   assert(iterateDequeNext(joined_deque, tail_it) == 0);
-  release((OBObjType *)tail_it);
+  OBRelease((OBObjType *)tail_it);
 
   tail_it = getDequeTailIt(joined_deque);
   addAtDequeIt(joined_deque, tail_it, (OBObjType *)a);
-  release((OBObjType *)tail_it);
+  OBRelease((OBObjType *)tail_it);
 
   tail_it = getDequeTailIt(joined_deque);
   copy_it = copyDequeIterator(tail_it);
-  release((OBObjType *)tail_it);
+  OBRelease((OBObjType *)tail_it);
   tail_it = copy_it;
   
 
@@ -142,7 +142,7 @@ int main (){
 
   assert(iterateDequePrev(joined_deque, tail_it) == 0);
 
-  release((OBObjType *)tail_it);
+  OBRelease((OBObjType *)tail_it);
 
   clearDeque(test_deque_a);
   clearDeque(test_deque_b);
@@ -153,16 +153,16 @@ int main (){
 
   assert(isDequeEmpty(joined_deque) != 0);
   assert(dequeLength(joined_deque) == 0);
-  assert(referenceCount((OBObjType *)a) == 1);
+  assert(OBReferenceCount((OBObjType *)a) == 1);
 
-  release((OBObjType *)test_deque_a);
-  release((OBObjType *)test_deque_b);
-  release((OBObjType *)joined_deque);
-  release((OBObjType *)e);
-  release((OBObjType *)d);
-  release((OBObjType *)c);
-  release((OBObjType *)b);
-  release((OBObjType *)a);
+  OBRelease((OBObjType *)test_deque_a);
+  OBRelease((OBObjType *)test_deque_b);
+  OBRelease((OBObjType *)joined_deque);
+  OBRelease((OBObjType *)e);
+  OBRelease((OBObjType *)d);
+  OBRelease((OBObjType *)c);
+  OBRelease((OBObjType *)b);
+  OBRelease((OBObjType *)a);
 
   printf("OBDeque_test: TESTS PASSED\n");
   return 0;

--- a/src/tests/OBDeque_test.c
+++ b/src/tests/OBDeque_test.c
@@ -17,7 +17,7 @@ int main (){
   uint32_t i;
 
   /* create test objects */
-  test_deque_a = createDeque();
+  test_deque_a = OBDequeCreate();
   a = createTest(1);
   b = createTest(2);
   c = createTest(3);
@@ -26,32 +26,32 @@ int main (){
 
 
   /* test the empty deque */
-  assert(isDequeEmpty(test_deque_a) != 0);
-  assert(dequeLength(test_deque_a) == 0);
-  assert(getDequeHeadIt(test_deque_a) == NULL);
-  assert(getDequeTailIt(test_deque_a) == NULL);
+  assert(OBDequeIsEmpty(test_deque_a) != 0);
+  assert(OBDequeLength(test_deque_a) == 0);
+  assert(OBDequeGetHeadIterator(test_deque_a) == NULL);
+  assert(OBDequeGetTailIterator(test_deque_a) == NULL);
 
   /* test a deque with a single element */
-  addDequeHead(test_deque_a, (OBObjType *)a);
+  OBDequeAddHead(test_deque_a, (OBObjType *)a);
 
-  assert(isDequeEmpty(test_deque_a) == 0);
-  assert(dequeLength(test_deque_a) == 1);
+  assert(OBDequeIsEmpty(test_deque_a) == 0);
+  assert(OBDequeLength(test_deque_a) == 1);
   assert(OBReferenceCount((OBObjType *)a) == 2);
-  assert(getTestID((OBTest *)objAtDequeHead(test_deque_a)) == 1);
-  assert(getTestID((OBTest *)objAtDequeTail(test_deque_a)) == 1);
+  assert(getTestID((OBTest *)OBDequeFirstObject(test_deque_a)) == 1);
+  assert(getTestID((OBTest *)OBDequeLastObject(test_deque_a)) == 1);
 
-  head_it = getDequeHeadIt(test_deque_a);
-  tail_it = getDequeTailIt(test_deque_a);
+  head_it = OBDequeGetHeadIterator(test_deque_a);
+  tail_it = OBDequeGetTailIterator(test_deque_a);
 
   assert(head_it != NULL);
   assert(tail_it != NULL);
-  assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, head_it)) == 1);
-  assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, tail_it)) == 1);
+  assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, head_it)) == 1);
+  assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, tail_it)) == 1);
 
-  assert(findObjInDeque(test_deque_a, (OBObjType *)a));
+  assert(OBDequeContains(test_deque_a, (OBObjType *)a));
 
   /* test removing the only element from the deque */
-  removeDequeTail(test_deque_a);
+  OBDequeRemoveLastObject(test_deque_a);
 
   /* check that element is still referenced because of existing iterators */
   assert(OBReferenceCount((OBObjType *)a) == 2);
@@ -60,99 +60,99 @@ int main (){
   assert(OBReferenceCount((OBObjType *)a) == 1);
 
 
-  assert(isDequeEmpty(test_deque_a) != 0);
-  assert(dequeLength(test_deque_a) == 0);
-  assert(getDequeHeadIt(test_deque_a) == NULL);
-  assert(getDequeTailIt(test_deque_a) == NULL);
+  assert(OBDequeIsEmpty(test_deque_a) != 0);
+  assert(OBDequeLength(test_deque_a) == 0);
+  assert(OBDequeGetHeadIterator(test_deque_a) == NULL);
+  assert(OBDequeGetTailIterator(test_deque_a) == NULL);
 
   /* test deque with multiple elements */
-  addDequeTail(test_deque_a, (OBObjType *)a);
-  addDequeHead(test_deque_a, (OBObjType *)b);
-  addDequeTail(test_deque_a, (OBObjType *)c);
-  addDequeHead(test_deque_a, (OBObjType *)d);
-  addDequeTail(test_deque_a, (OBObjType *)e);
+  OBDequeAddTail(test_deque_a, (OBObjType *)a);
+  OBDequeAddHead(test_deque_a, (OBObjType *)b);
+  OBDequeAddTail(test_deque_a, (OBObjType *)c);
+  OBDequeAddHead(test_deque_a, (OBObjType *)d);
+  OBDequeAddTail(test_deque_a, (OBObjType *)e);
 
-  assert(isDequeEmpty(test_deque_a) == 0);
-  assert(dequeLength(test_deque_a) == 5);
+  assert(OBDequeIsEmpty(test_deque_a) == 0);
+  assert(OBDequeLength(test_deque_a) == 5);
 
   /* test deque removal functions */
-  head_it = getDequeHeadIt(test_deque_a);
-  removeDequeAtIt(test_deque_a, head_it);
+  head_it = OBDequeGetHeadIterator(test_deque_a);
+  OBDequeRemoveAtIterator(test_deque_a, head_it);
   OBRelease((OBObjType *)head_it);
 
-  head_it = getDequeHeadIt(test_deque_a);
+  head_it = OBDequeGetHeadIterator(test_deque_a);
   do{
-    assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, head_it)) != 4);
-  }while(iterateDequeNext(test_deque_a, head_it));
+    assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, head_it)) != 4);
+  }while(OBDequeIterateNext(test_deque_a, head_it));
 
   OBRelease((OBObjType *)head_it);
-  addDequeHead(test_deque_a, (OBObjType *)d);
+  OBDequeAddHead(test_deque_a, (OBObjType *)d);
 
-  test_deque_b = copyDeque(test_deque_a);
+  test_deque_b = OBDequeCopy(test_deque_a);
 
   assert(OBReferenceCount((OBObjType *)a) == 3);
   assert(OBCompare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_EQUAL_TO);
   assert(OBHash((OBObjType *)test_deque_a) ==  OBHash((OBObjType *)test_deque_b));
 
-  sortDeque(test_deque_a, OB_LEAST_TO_GREATEST);
+  OBDequeSort(test_deque_a, OB_LEAST_TO_GREATEST);
 
-  assert(dequeLength(test_deque_a) == 5);
+  assert(OBDequeLength(test_deque_a) == 5);
   assert(OBCompare((OBObjType *)test_deque_a, (OBObjType *)test_deque_b) == OB_NOT_EQUAL);
   assert(OBHash((OBObjType *)test_deque_a) !=  OBHash((OBObjType *)test_deque_b));
 
   i = 1;
-  head_it = getDequeHeadIt(test_deque_a);
+  head_it = OBDequeGetHeadIterator(test_deque_a);
   do{
-    assert(getTestID((OBTest *)objAtDequeIt(test_deque_a, head_it)) == i);
+    assert(getTestID((OBTest *)OBDequeObjAtIterator(test_deque_a, head_it)) == i);
     i++;
-  }while(iterateDequeNext(test_deque_a, head_it));
+  }while(OBDequeIterateNext(test_deque_a, head_it));
 
   OBRelease((OBObjType *)head_it);
   OBRelease((OBObjType *)test_deque_a);
   assert(OBReferenceCount((OBObjType *)a) == 2);
 
-  test_deque_a = copyDeque(test_deque_b);
-  joined_deque = joinDeques(test_deque_a, test_deque_b);
-  sortDeque(joined_deque, OB_GREATEST_TO_LEAST);
+  test_deque_a = OBDequeCopy(test_deque_b);
+  joined_deque = OBDequeJoin(test_deque_a, test_deque_b);
+  OBDequeSort(joined_deque, OB_GREATEST_TO_LEAST);
 
-  assert(dequeLength(joined_deque) == 10);
+  assert(OBDequeLength(joined_deque) == 10);
   assert(OBReferenceCount((OBObjType *)a) == 5); /* the joined deque has two references,
                                             as a is contained within twice */
   
-  tail_it = getDequeTailIt(joined_deque);
-  removeDequeTail(joined_deque);
-  assert(iterateDequePrev(joined_deque, tail_it) == 0);
-  assert(iterateDequeNext(joined_deque, tail_it) == 0);
+  tail_it = OBDequeGetTailIterator(joined_deque);
+  OBDequeRemoveLastObject(joined_deque);
+  assert(OBDequeIteratePrevious(joined_deque, tail_it) == 0);
+  assert(OBDequeIterateNext(joined_deque, tail_it) == 0);
   OBRelease((OBObjType *)tail_it);
 
-  tail_it = getDequeTailIt(joined_deque);
-  addAtDequeIt(joined_deque, tail_it, (OBObjType *)a);
+  tail_it = OBDequeGetTailIterator(joined_deque);
+  OBDeuqueAddAtIterator(joined_deque, tail_it, (OBObjType *)a);
   OBRelease((OBObjType *)tail_it);
 
-  tail_it = getDequeTailIt(joined_deque);
-  copy_it = copyDequeIterator(tail_it);
+  tail_it = OBDequeGetTailIterator(joined_deque);
+  copy_it = OBDequeIteratorCopy(tail_it);
   OBRelease((OBObjType *)tail_it);
   tail_it = copy_it;
   
 
   for(i=0; i<10; i++){
-    assert(getTestID((OBTest *)objAtDequeIt(joined_deque, tail_it)) == i/2+1);
-    if(i != 9) assert(iterateDequePrev(joined_deque, tail_it));
+    assert(getTestID((OBTest *)OBDequeObjAtIterator(joined_deque, tail_it)) == i/2+1);
+    if(i != 9) assert(OBDequeIteratePrevious(joined_deque, tail_it));
   }
 
-  assert(iterateDequePrev(joined_deque, tail_it) == 0);
+  assert(OBDequeIteratePrevious(joined_deque, tail_it) == 0);
 
   OBRelease((OBObjType *)tail_it);
 
-  clearDeque(test_deque_a);
-  clearDeque(test_deque_b);
+  OBDequeClear(test_deque_a);
+  OBDequeClear(test_deque_b);
 
   for(i=0; i<10; i++){
-    removeDequeHead(joined_deque);
+    OBDequeRemoveFirstObject(joined_deque);
   }
 
-  assert(isDequeEmpty(joined_deque) != 0);
-  assert(dequeLength(joined_deque) == 0);
+  assert(OBDequeIsEmpty(joined_deque) != 0);
+  assert(OBDequeLength(joined_deque) == 0);
   assert(OBReferenceCount((OBObjType *)a) == 1);
 
   OBRelease((OBObjType *)test_deque_a);

--- a/src/tests/OBInt_test.c
+++ b/src/tests/OBInt_test.c
@@ -18,12 +18,12 @@ int main (){
 	OBString *str1, *str2;
 
   /* test machine integer creation and value methods */
-  a = createIntWithInt(1024);
-  assert(intValue(a) == 1024);
-  b = createIntWithInt(9581085);
-  assert(intValue(b) == 9581085);
-  c = createIntWithInt(-999);
-  assert(intValue(c) == -999);
+  a = OBIntCreate(1024);
+  assert(OBIntGetIntValue(a) == 1024);
+  b = OBIntCreate(9581085);
+  assert(OBIntGetIntValue(b) == 9581085);
+  c = OBIntCreate(-999);
+  assert(OBIntGetIntValue(c) == -999);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
@@ -31,9 +31,9 @@ int main (){
 
 	/* test string integer creation and value methods */
 	str1 = createString("12345");
-	a = intFromString(str1);
-	assert(intValue(a) == 12345);
-	str2 = stringFromInt(a);
+	a = OBIntCreateFromString(str1);
+	assert(OBIntGetIntValue(a) == 12345);
+	str2 = OBIntGetStringValue(a);
 	assert(OBCompare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 	
 	OBRelease((OBObjType *)a);
@@ -41,11 +41,11 @@ int main (){
 	OBRelease((OBObjType *)str2);
 
 	str1 = createString("-012345");
-	a = intFromString(str1);
+	a = OBIntCreateFromString(str1);
 	OBRelease((OBObjType *)str1);
-	assert(intValue(a) == -12345);
+	assert(OBIntGetIntValue(a) == -12345);
 	str1 = createString("-12345");
-	str2 = stringFromInt(a);
+	str2 = OBIntGetStringValue(a);
 	assert(OBCompare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 
 	OBRelease((OBObjType *)a);
@@ -53,8 +53,8 @@ int main (){
 	OBRelease((OBObjType *)str2);
 
 	/* test copy method */
-	a = createIntWithInt(918394);
-	b = copyInt(a);
+	a = OBIntCreate(918394);
+	b = OBIntCopy(a);
 	assert(OBCompare((OBObjType *)a, (OBObjType *)b) == OB_EQUAL_TO);
 	assert(a != b);
 	assert(a->digits != b->digits);
@@ -63,71 +63,71 @@ int main (){
 	OBRelease((OBObjType *)b);
 
 	/* test integer zero and negative methods */
-	a = createIntWithInt(1948);
-	b = createIntWithInt(-1);
+	a = OBIntCreate(1948);
+	b = OBIntCreate(-1);
 	str1 = createString("-0");
-	c = intFromString(str1);
+	c = OBIntCreateFromString(str1);
 	OBRelease((OBObjType *)str1);
 	
-	assert(!isIntZero(a));
-	assert(!isIntZero(b));
-	assert(isIntZero(c));
+	assert(!OBIntIsZero(a));
+	assert(!OBIntIsZero(b));
+	assert(OBIntIsZero(c));
 
-	assert(!isIntNegative(a));
-	assert(isIntNegative(b));
-	assert(!isIntNegative(c));
+	assert(!OBIntIsNegative(a));
+	assert(OBIntIsNegative(b));
+	assert(!OBIntIsNegative(c));
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
   /* test integer addition */
-  a = createIntWithInt(999);
-  b = addIntAndPrim(a, 1111);
-  assert(intValue(b) == 2110);
-  c = addInts(a, b);
-  assert(intValue(c) == 2110 + 999);
+  a = OBIntCreate(999);
+  b = OBIntAddPrimitive(a, 1111);
+  assert(OBIntGetIntValue(b) == 2110);
+  c = OBIntAdd(a, b);
+  assert(OBIntGetIntValue(c) == 2110 + 999);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(-999);
-  b = addIntAndPrim(a, 1);
-  assert(intValue(b) == -998);
+  a = OBIntCreate(-999);
+  b = OBIntAddPrimitive(a, 1);
+  assert(OBIntGetIntValue(b) == -998);
   OBRelease((OBObjType *)b);
-  b = addIntAndPrim(a, -1);
-  assert(intValue(b) == -1000);
+  b = OBIntAddPrimitive(a, -1);
+  assert(OBIntGetIntValue(b) == -1000);
   OBRelease((OBObjType *)b);
-  b = createIntWithInt(1000);
-  c = addInts(a, b);
-  assert(intValue(c) == 1);
+  b = OBIntCreate(1000);
+  c = OBIntAdd(a, b);
+  assert(OBIntGetIntValue(c) == 1);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
   /* test integer subtraction */
-  a = createIntWithInt(999);
-  b = subtractIntWithPrim(a, 1111);
-  assert(intValue(b) == -112);
-  c = subtractInts(a, b);
-  assert(intValue(c) == 999 + 112);
+  a = OBIntCreate(999);
+  b = OBIntSubtractPrimitive(a, 1111);
+  assert(OBIntGetIntValue(b) == -112);
+  c = OBIntSubtract(a, b);
+  assert(OBIntGetIntValue(c) == 999 + 112);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(-999);
-  b = subtractIntWithPrim(a, 1);
-  assert(intValue(b) == -1000);
+  a = OBIntCreate(-999);
+  b = OBIntSubtractPrimitive(a, 1);
+  assert(OBIntGetIntValue(b) == -1000);
   OBRelease((OBObjType *)b);
-  b = subtractIntWithPrim(a, -1);
-  assert(intValue(b) == -998);
+  b = OBIntSubtractPrimitive(a, -1);
+  assert(OBIntGetIntValue(b) == -998);
   OBRelease((OBObjType *)b);
-  b = createIntWithInt(1000);
-  c = subtractInts(a, b);
-  assert(intValue(c) == -1999);
+  b = OBIntCreate(1000);
+  c = OBIntSubtract(a, b);
+  assert(OBIntGetIntValue(c) == -1999);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
@@ -135,52 +135,52 @@ int main (){
 
   /* test integer multiplication (size under digit limit for explicit integer
    * arithmetic) */
-  a = createIntWithInt(999);
-  b = multiplyIntAndPrim(a, -999);
-  assert(intValue(b) == 999*-999);
-  c = multiplyInts(a, b);
-  assert(intValue(c) == 999*999*-999);
+  a = OBIntCreate(999);
+  b = OBIntMultiplyPrimitive(a, -999);
+  assert(OBIntGetIntValue(b) == 999*-999);
+  c = OBIntMultiply(a, b);
+  assert(OBIntGetIntValue(c) == 999*999*-999);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(-1928491);
-  b = multiplyIntAndPrim(a, -58);
-  assert(intValue(b) == -1928491*-58);
+  a = OBIntCreate(-1928491);
+  b = OBIntMultiplyPrimitive(a, -58);
+  assert(OBIntGetIntValue(b) == -1928491*-58);
   OBRelease((OBObjType *)b);
-  b = createIntWithInt(2);
-  c = multiplyInts(a, b);
-  assert(intValue(c) == -1928491*2);
+  b = OBIntCreate(2);
+  c = OBIntMultiply(a, b);
+  assert(OBIntGetIntValue(c) == -1928491*2);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(29458);
-  b = multiplyIntAndPrim(a, 0);
-  assert(isIntZero(b) != 0);
+  a = OBIntCreate(29458);
+  b = OBIntMultiplyPrimitive(a, 0);
+  assert(OBIntIsZero(b) != 0);
 
   OBRelease((OBObjType *)a);
   OBRelease((OBObjType *)b);
 
   /* test integer division (size under digit limit for explicit integer
    * arithmetic) */
-  a = createIntWithInt(999);
-  b = divideIntWithPrim(a, -999);
-  assert(intValue(b) == -1);
-  c = divideIntWithPrim(a, 33);
-  assert(intValue(c) == 999/33);
+  a = OBIntCreate(999);
+  b = OBIntDividePrimitive(a, -999);
+  assert(OBIntGetIntValue(b) == -1);
+  c = OBIntDividePrimitive(a, 33);
+  assert(OBIntGetIntValue(c) == 999/33);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(1940248);
-  b = divideIntWithPrim(a, -2848);
-  assert(intValue(b) == 1940248/(-2848));
-  c = divideInts(a, b);
-  assert(intValue(c) == 1940248/(1940248/(-2848)));
+  a = OBIntCreate(1940248);
+  b = OBIntDividePrimitive(a, -2848);
+  assert(OBIntGetIntValue(b) == 1940248/(-2848));
+  c = OBIntDivide(a, b);
+  assert(OBIntGetIntValue(c) == 1940248/(1940248/(-2848)));
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
@@ -188,21 +188,21 @@ int main (){
 
   /* test integer modulus (size under digit limit for explicit integer
    * arithmetic) */
-  a = createIntWithInt(999);
-  b = modIntWithPrim(a, -999);
-  assert(intValue(b) == 999%(-999));
-  c = modIntWithPrim(a, 33);
-  assert(intValue(c) == 999%33);
+  a = OBIntCreate(999);
+  b = OBIntModPrimitive(a, -999);
+  assert(OBIntGetIntValue(b) == 999%(-999));
+  c = OBIntModPrimitive(a, 33);
+  assert(OBIntGetIntValue(c) == 999%33);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(1940248);
-  b = modIntWithPrim(a, -2848);
-  assert(intValue(b) == 1940248%(-2848));
-  c = modInts(a, b);
-  assert(intValue(c) == 1940248%(1940248%(-2848)));
+  a = OBIntCreate(1940248);
+  b = OBIntModPrimitive(a, -2848);
+  assert(OBIntGetIntValue(b) == 1940248%(-2848));
+  c = OBIntMod(a, b);
+  assert(OBIntGetIntValue(c) == 1940248%(1940248%(-2848)));
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
@@ -213,52 +213,52 @@ int main (){
 
   /* test integer multiplication (size over digit limit for explicit integer
    * arithmetic) */
-  a = createIntWithInt(999);
-  b = multiplyIntAndPrim(a, -999);
-  assert(intValue(b) == 999*-999);
-  c = multiplyInts(a, b);
-  assert(intValue(c) == 999*999*-999);
+  a = OBIntCreate(999);
+  b = OBIntMultiplyPrimitive(a, -999);
+  assert(OBIntGetIntValue(b) == 999*-999);
+  c = OBIntMultiply(a, b);
+  assert(OBIntGetIntValue(c) == 999*999*-999);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(-1928491);
-  b = multiplyIntAndPrim(a, -58);
-  assert(intValue(b) == -1928491*-58);
+  a = OBIntCreate(-1928491);
+  b = OBIntMultiplyPrimitive(a, -58);
+  assert(OBIntGetIntValue(b) == -1928491*-58);
   OBRelease((OBObjType *)b);
-  b = createIntWithInt(2);
-  c = multiplyInts(a, b);
-  assert(intValue(c) == -1928491*2);
+  b = OBIntCreate(2);
+  c = OBIntMultiply(a, b);
+  assert(OBIntGetIntValue(c) == -1928491*2);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(29458);
-  b = multiplyIntAndPrim(a, 0);
-  assert(isIntZero(b) != 0);
+  a = OBIntCreate(29458);
+  b = OBIntMultiplyPrimitive(a, 0);
+  assert(OBIntIsZero(b) != 0);
 
   OBRelease((OBObjType *)a);
   OBRelease((OBObjType *)b);
 
   /* test integer division (size under digit limit for explicit integer
    * arithmetic) */
-  a = createIntWithInt(999);
-  b = divideIntWithPrim(a, -999);
-  assert(intValue(b) == -1);
-  c = divideIntWithPrim(a, 33);
-  assert(intValue(c) == 999/33);
+  a = OBIntCreate(999);
+  b = OBIntDividePrimitive(a, -999);
+  assert(OBIntGetIntValue(b) == -1);
+  c = OBIntDividePrimitive(a, 33);
+  assert(OBIntGetIntValue(c) == 999/33);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(1940248);
-  b = divideIntWithPrim(a, -2848);
-  assert(intValue(b) == 1940248/(-2848));
-  c = divideInts(a, b);
-  assert(intValue(c) == 1940248/(1940248/(-2848)));
+  a = OBIntCreate(1940248);
+  b = OBIntDividePrimitive(a, -2848);
+  assert(OBIntGetIntValue(b) == 1940248/(-2848));
+  c = OBIntDivide(a, b);
+  assert(OBIntGetIntValue(c) == 1940248/(1940248/(-2848)));
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
@@ -266,21 +266,21 @@ int main (){
 
   /* test integer modulus (size over digit limit for explicit integer
    * arithmetic) */
-  a = createIntWithInt(999);
-  b = modIntWithPrim(a, -999);
-  assert(intValue(b) == 999%(-999));
-  c = modIntWithPrim(a, 33);
-  assert(intValue(c) == 999%33);
+  a = OBIntCreate(999);
+  b = OBIntModPrimitive(a, -999);
+  assert(OBIntGetIntValue(b) == 999%(-999));
+  c = OBIntModPrimitive(a, 33);
+  assert(OBIntGetIntValue(c) == 999%33);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);
 	OBRelease((OBObjType *)c);
 
-  a = createIntWithInt(1940248);
-  b = modIntWithPrim(a, -2848);
-  assert(intValue(b) == 1940248%(-2848));
-  c = modInts(a, b);
-  assert(intValue(c) == 1940248%(1940248%(-2848)));
+  a = OBIntCreate(1940248);
+  b = OBIntModPrimitive(a, -2848);
+  assert(OBIntGetIntValue(b) == 1940248%(-2848));
+  c = OBIntMod(a, b);
+  assert(OBIntGetIntValue(c) == 1940248%(1940248%(-2848)));
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)b);

--- a/src/tests/OBInt_test.c
+++ b/src/tests/OBInt_test.c
@@ -34,7 +34,7 @@ int main (){
 	a = intFromString(str1);
 	assert(intValue(a) == 12345);
 	str2 = stringFromInt(a);
-	assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
+	assert(OBCompare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 	
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)str1);
@@ -46,7 +46,7 @@ int main (){
 	assert(intValue(a) == -12345);
 	str1 = createString("-12345");
 	str2 = stringFromInt(a);
-	assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
+	assert(OBCompare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 
 	OBRelease((OBObjType *)a);
 	OBRelease((OBObjType *)str1);
@@ -55,7 +55,7 @@ int main (){
 	/* test copy method */
 	a = createIntWithInt(918394);
 	b = copyInt(a);
-	assert(compare((OBObjType *)a, (OBObjType *)b) == OB_EQUAL_TO);
+	assert(OBCompare((OBObjType *)a, (OBObjType *)b) == OB_EQUAL_TO);
 	assert(a != b);
 	assert(a->digits != b->digits);
 

--- a/src/tests/OBInt_test.c
+++ b/src/tests/OBInt_test.c
@@ -25,9 +25,9 @@ int main (){
   c = createIntWithInt(-999);
   assert(intValue(c) == -999);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
 	/* test string integer creation and value methods */
 	str1 = createString("12345");
@@ -36,21 +36,21 @@ int main (){
 	str2 = stringFromInt(a);
 	assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 	
-	release((OBObjType *)a);
-	release((OBObjType *)str1);
-	release((OBObjType *)str2);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)str1);
+	OBRelease((OBObjType *)str2);
 
 	str1 = createString("-012345");
 	a = intFromString(str1);
-	release((OBObjType *)str1);
+	OBRelease((OBObjType *)str1);
 	assert(intValue(a) == -12345);
 	str1 = createString("-12345");
 	str2 = stringFromInt(a);
 	assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 
-	release((OBObjType *)a);
-	release((OBObjType *)str1);
-	release((OBObjType *)str2);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)str1);
+	OBRelease((OBObjType *)str2);
 
 	/* test copy method */
 	a = createIntWithInt(918394);
@@ -59,15 +59,15 @@ int main (){
 	assert(a != b);
 	assert(a->digits != b->digits);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
 
 	/* test integer zero and negative methods */
 	a = createIntWithInt(1948);
 	b = createIntWithInt(-1);
 	str1 = createString("-0");
 	c = intFromString(str1);
-	release((OBObjType *)str1);
+	OBRelease((OBObjType *)str1);
 	
 	assert(!isIntZero(a));
 	assert(!isIntZero(b));
@@ -77,9 +77,9 @@ int main (){
 	assert(isIntNegative(b));
 	assert(!isIntNegative(c));
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   /* test integer addition */
   a = createIntWithInt(999);
@@ -88,24 +88,24 @@ int main (){
   c = addInts(a, b);
   assert(intValue(c) == 2110 + 999);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(-999);
   b = addIntAndPrim(a, 1);
   assert(intValue(b) == -998);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)b);
   b = addIntAndPrim(a, -1);
   assert(intValue(b) == -1000);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)b);
   b = createIntWithInt(1000);
   c = addInts(a, b);
   assert(intValue(c) == 1);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   /* test integer subtraction */
   a = createIntWithInt(999);
@@ -114,24 +114,24 @@ int main (){
   c = subtractInts(a, b);
   assert(intValue(c) == 999 + 112);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(-999);
   b = subtractIntWithPrim(a, 1);
   assert(intValue(b) == -1000);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)b);
   b = subtractIntWithPrim(a, -1);
   assert(intValue(b) == -998);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)b);
   b = createIntWithInt(1000);
   c = subtractInts(a, b);
   assert(intValue(c) == -1999);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   /* test integer multiplication (size under digit limit for explicit integer
    * arithmetic) */
@@ -141,28 +141,28 @@ int main (){
   c = multiplyInts(a, b);
   assert(intValue(c) == 999*999*-999);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(-1928491);
   b = multiplyIntAndPrim(a, -58);
   assert(intValue(b) == -1928491*-58);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)b);
   b = createIntWithInt(2);
   c = multiplyInts(a, b);
   assert(intValue(c) == -1928491*2);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(29458);
   b = multiplyIntAndPrim(a, 0);
   assert(isIntZero(b) != 0);
 
-  release((OBObjType *)a);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)a);
+  OBRelease((OBObjType *)b);
 
   /* test integer division (size under digit limit for explicit integer
    * arithmetic) */
@@ -172,9 +172,9 @@ int main (){
   c = divideIntWithPrim(a, 33);
   assert(intValue(c) == 999/33);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = divideIntWithPrim(a, -2848);
@@ -182,9 +182,9 @@ int main (){
   c = divideInts(a, b);
   assert(intValue(c) == 1940248/(1940248/(-2848)));
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   /* test integer modulus (size under digit limit for explicit integer
    * arithmetic) */
@@ -194,9 +194,9 @@ int main (){
   c = modIntWithPrim(a, 33);
   assert(intValue(c) == 999%33);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = modIntWithPrim(a, -2848);
@@ -204,9 +204,9 @@ int main (){
   c = modInts(a, b);
   assert(intValue(c) == 1940248%(1940248%(-2848)));
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   /* set digit limit for integer arithmetic low, for test purposes */
   setMaxDigits(2);
@@ -219,28 +219,28 @@ int main (){
   c = multiplyInts(a, b);
   assert(intValue(c) == 999*999*-999);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(-1928491);
   b = multiplyIntAndPrim(a, -58);
   assert(intValue(b) == -1928491*-58);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)b);
   b = createIntWithInt(2);
   c = multiplyInts(a, b);
   assert(intValue(c) == -1928491*2);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(29458);
   b = multiplyIntAndPrim(a, 0);
   assert(isIntZero(b) != 0);
 
-  release((OBObjType *)a);
-  release((OBObjType *)b);
+  OBRelease((OBObjType *)a);
+  OBRelease((OBObjType *)b);
 
   /* test integer division (size under digit limit for explicit integer
    * arithmetic) */
@@ -250,9 +250,9 @@ int main (){
   c = divideIntWithPrim(a, 33);
   assert(intValue(c) == 999/33);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = divideIntWithPrim(a, -2848);
@@ -260,9 +260,9 @@ int main (){
   c = divideInts(a, b);
   assert(intValue(c) == 1940248/(1940248/(-2848)));
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   /* test integer modulus (size over digit limit for explicit integer
    * arithmetic) */
@@ -272,9 +272,9 @@ int main (){
   c = modIntWithPrim(a, 33);
   assert(intValue(c) == 999%33);
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = modIntWithPrim(a, -2848);
@@ -282,9 +282,9 @@ int main (){
   c = modInts(a, b);
   assert(intValue(c) == 1940248%(1940248%(-2848)));
 
-	release((OBObjType *)a);
-	release((OBObjType *)b);
-	release((OBObjType *)c);
+	OBRelease((OBObjType *)a);
+	OBRelease((OBObjType *)b);
+	OBRelease((OBObjType *)c);
 
   printf("OBInt_test: TESTS PASSED\n");
   return 0;

--- a/src/tests/OBInt_test.c
+++ b/src/tests/OBInt_test.c
@@ -30,7 +30,7 @@ int main (){
 	OBRelease((OBObjType *)c);
 
 	/* test string integer creation and value methods */
-	str1 = createString("12345");
+	str1 = OBStringCreate("12345");
 	a = OBIntCreateFromString(str1);
 	assert(OBIntGetIntValue(a) == 12345);
 	str2 = OBIntGetStringValue(a);
@@ -40,11 +40,11 @@ int main (){
 	OBRelease((OBObjType *)str1);
 	OBRelease((OBObjType *)str2);
 
-	str1 = createString("-012345");
+	str1 = OBStringCreate("-012345");
 	a = OBIntCreateFromString(str1);
 	OBRelease((OBObjType *)str1);
 	assert(OBIntGetIntValue(a) == -12345);
-	str1 = createString("-12345");
+	str1 = OBStringCreate("-12345");
 	str2 = OBIntGetStringValue(a);
 	assert(OBCompare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 
@@ -65,7 +65,7 @@ int main (){
 	/* test integer zero and negative methods */
 	a = OBIntCreate(1948);
 	b = OBIntCreate(-1);
-	str1 = createString("-0");
+	str1 = OBStringCreate("-0");
 	c = OBIntCreateFromString(str1);
 	OBRelease((OBObjType *)str1);
 	
@@ -209,7 +209,7 @@ int main (){
 	OBRelease((OBObjType *)c);
 
   /* set digit limit for integer arithmetic low, for test purposes */
-  setMaxDigits(2);
+  OBIntSetMaxDigits(2);
 
   /* test integer multiplication (size over digit limit for explicit integer
    * arithmetic) */

--- a/src/tests/OBInt_test.c
+++ b/src/tests/OBInt_test.c
@@ -25,49 +25,49 @@ int main (){
   c = createIntWithInt(-999);
   assert(intValue(c) == -999);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
 	/* test string integer creation and value methods */
 	str1 = createString("12345");
 	a = intFromString(str1);
 	assert(intValue(a) == 12345);
 	str2 = stringFromInt(a);
-	assert(compare((obj *)str1, (obj *)str2) == OB_EQUAL_TO);
+	assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 	
-	release((obj *)a);
-	release((obj *)str1);
-	release((obj *)str2);
+	release((OBObjType *)a);
+	release((OBObjType *)str1);
+	release((OBObjType *)str2);
 
 	str1 = createString("-012345");
 	a = intFromString(str1);
-	release((obj *)str1);
+	release((OBObjType *)str1);
 	assert(intValue(a) == -12345);
 	str1 = createString("-12345");
 	str2 = stringFromInt(a);
-	assert(compare((obj *)str1, (obj *)str2) == OB_EQUAL_TO);
+	assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
 
-	release((obj *)a);
-	release((obj *)str1);
-	release((obj *)str2);
+	release((OBObjType *)a);
+	release((OBObjType *)str1);
+	release((OBObjType *)str2);
 
 	/* test copy method */
 	a = createIntWithInt(918394);
 	b = copyInt(a);
-	assert(compare((obj *)a, (obj *)b) == OB_EQUAL_TO);
+	assert(compare((OBObjType *)a, (OBObjType *)b) == OB_EQUAL_TO);
 	assert(a != b);
 	assert(a->digits != b->digits);
 
-	release((obj *)a);
-	release((obj *)b);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
 
 	/* test integer zero and negative methods */
 	a = createIntWithInt(1948);
 	b = createIntWithInt(-1);
 	str1 = createString("-0");
 	c = intFromString(str1);
-	release((obj *)str1);
+	release((OBObjType *)str1);
 	
 	assert(!isIntZero(a));
 	assert(!isIntZero(b));
@@ -77,9 +77,9 @@ int main (){
 	assert(isIntNegative(b));
 	assert(!isIntNegative(c));
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   /* test integer addition */
   a = createIntWithInt(999);
@@ -88,24 +88,24 @@ int main (){
   c = addInts(a, b);
   assert(intValue(c) == 2110 + 999);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(-999);
   b = addIntAndPrim(a, 1);
   assert(intValue(b) == -998);
-  release((obj *)b);
+  release((OBObjType *)b);
   b = addIntAndPrim(a, -1);
   assert(intValue(b) == -1000);
-  release((obj *)b);
+  release((OBObjType *)b);
   b = createIntWithInt(1000);
   c = addInts(a, b);
   assert(intValue(c) == 1);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   /* test integer subtraction */
   a = createIntWithInt(999);
@@ -114,24 +114,24 @@ int main (){
   c = subtractInts(a, b);
   assert(intValue(c) == 999 + 112);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(-999);
   b = subtractIntWithPrim(a, 1);
   assert(intValue(b) == -1000);
-  release((obj *)b);
+  release((OBObjType *)b);
   b = subtractIntWithPrim(a, -1);
   assert(intValue(b) == -998);
-  release((obj *)b);
+  release((OBObjType *)b);
   b = createIntWithInt(1000);
   c = subtractInts(a, b);
   assert(intValue(c) == -1999);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   /* test integer multiplication (size under digit limit for explicit integer
    * arithmetic) */
@@ -141,28 +141,28 @@ int main (){
   c = multiplyInts(a, b);
   assert(intValue(c) == 999*999*-999);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(-1928491);
   b = multiplyIntAndPrim(a, -58);
   assert(intValue(b) == -1928491*-58);
-  release((obj *)b);
+  release((OBObjType *)b);
   b = createIntWithInt(2);
   c = multiplyInts(a, b);
   assert(intValue(c) == -1928491*2);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(29458);
   b = multiplyIntAndPrim(a, 0);
   assert(isIntZero(b) != 0);
 
-  release((obj *)a);
-  release((obj *)b);
+  release((OBObjType *)a);
+  release((OBObjType *)b);
 
   /* test integer division (size under digit limit for explicit integer
    * arithmetic) */
@@ -172,9 +172,9 @@ int main (){
   c = divideIntWithPrim(a, 33);
   assert(intValue(c) == 999/33);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = divideIntWithPrim(a, -2848);
@@ -182,9 +182,9 @@ int main (){
   c = divideInts(a, b);
   assert(intValue(c) == 1940248/(1940248/(-2848)));
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   /* test integer modulus (size under digit limit for explicit integer
    * arithmetic) */
@@ -194,9 +194,9 @@ int main (){
   c = modIntWithPrim(a, 33);
   assert(intValue(c) == 999%33);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = modIntWithPrim(a, -2848);
@@ -204,9 +204,9 @@ int main (){
   c = modInts(a, b);
   assert(intValue(c) == 1940248%(1940248%(-2848)));
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   /* set digit limit for integer arithmetic low, for test purposes */
   setMaxDigits(2);
@@ -219,28 +219,28 @@ int main (){
   c = multiplyInts(a, b);
   assert(intValue(c) == 999*999*-999);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(-1928491);
   b = multiplyIntAndPrim(a, -58);
   assert(intValue(b) == -1928491*-58);
-  release((obj *)b);
+  release((OBObjType *)b);
   b = createIntWithInt(2);
   c = multiplyInts(a, b);
   assert(intValue(c) == -1928491*2);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(29458);
   b = multiplyIntAndPrim(a, 0);
   assert(isIntZero(b) != 0);
 
-  release((obj *)a);
-  release((obj *)b);
+  release((OBObjType *)a);
+  release((OBObjType *)b);
 
   /* test integer division (size under digit limit for explicit integer
    * arithmetic) */
@@ -250,9 +250,9 @@ int main (){
   c = divideIntWithPrim(a, 33);
   assert(intValue(c) == 999/33);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = divideIntWithPrim(a, -2848);
@@ -260,9 +260,9 @@ int main (){
   c = divideInts(a, b);
   assert(intValue(c) == 1940248/(1940248/(-2848)));
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   /* test integer modulus (size over digit limit for explicit integer
    * arithmetic) */
@@ -272,9 +272,9 @@ int main (){
   c = modIntWithPrim(a, 33);
   assert(intValue(c) == 999%33);
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   a = createIntWithInt(1940248);
   b = modIntWithPrim(a, -2848);
@@ -282,9 +282,9 @@ int main (){
   c = modInts(a, b);
   assert(intValue(c) == 1940248%(1940248%(-2848)));
 
-	release((obj *)a);
-	release((obj *)b);
-	release((obj *)c);
+	release((OBObjType *)a);
+	release((OBObjType *)b);
+	release((OBObjType *)c);
 
   printf("OBInt_test: TESTS PASSED\n");
   return 0;

--- a/src/tests/OBMap_test.c
+++ b/src/tests/OBMap_test.c
@@ -24,87 +24,87 @@ int main (){
   OBTest *test_array[ARRAY_SIZE];
   OBTest *test;
 
-  test_map = createMap(); 
-  a = createTest(1);
-  b = createTest(2);
-  c = createTest(3);
-  d = createTest(103923);
-  e = createTest(1+MAP_CAPACITIES[0]); /* ensures hash collision with a */
-  f = createTest(1+2*MAP_CAPACITIES[0]);
-  g = createTest(1+3*MAP_CAPACITIES[0]);
-  h = createTest(1+4*MAP_CAPACITIES[0]);
+  test_map = OBMapCreate(); 
+  a = OBTestCreate(1);
+  b = OBTestCreate(2);
+  c = OBTestCreate(3);
+  d = OBTestCreate(103923);
+  e = OBTestCreate(1+MAP_CAPACITIES[0]); /* ensures hash collision with a */
+  f = OBTestCreate(1+2*MAP_CAPACITIES[0]);
+  g = OBTestCreate(1+3*MAP_CAPACITIES[0]);
+  h = OBTestCreate(1+4*MAP_CAPACITIES[0]);
 
   assert(OBHash((OBObjType *)a)%MAP_CAPACITIES[0] == OBHash((OBObjType *)e)%MAP_CAPACITIES[0]);
 
-  assert(lookupMapKey(test_map, (OBObjType *)a) == NULL);
+  assert(OBMapGetValueForKey(test_map, (OBObjType *)a) == NULL);
 
-  addToMap(test_map, (OBObjType *)a, (OBObjType *)b);
-  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
+  OBMapAdd(test_map, (OBObjType *)a, (OBObjType *)b);
+  test = (OBTest *)OBMapGetValueForKey(test_map, (OBObjType *)a);
 
   assert(test);
   assert(OBCompare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
   assert(OBReferenceCount((OBObjType *)test) > 1);
 
-  addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
-  addToMap(test_map, (OBObjType *)f, (OBObjType *)d);
-  addToMap(test_map, (OBObjType *)g, (OBObjType *)e);
-  addToMap(test_map, (OBObjType *)h, (OBObjType *)f);
-  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
+  OBMapAdd(test_map, (OBObjType *)e, (OBObjType *)c);
+  OBMapAdd(test_map, (OBObjType *)f, (OBObjType *)d);
+  OBMapAdd(test_map, (OBObjType *)g, (OBObjType *)e);
+  OBMapAdd(test_map, (OBObjType *)h, (OBObjType *)f);
+  test = (OBTest *)OBMapGetValueForKey(test_map, (OBObjType *)a);
 
   assert(OBCompare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
   assert(OBCompare((OBObjType *)c, (OBObjType *)test) != OB_EQUAL_TO);
 
-  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)e);
+  test = (OBTest *)OBMapGetValueForKey(test_map, (OBObjType *)e);
   
   assert(OBCompare((OBObjType *)c, (OBObjType *)test) == OB_EQUAL_TO);
   assert(OBCompare((OBObjType *)b, (OBObjType *)test) != OB_EQUAL_TO);
   
-  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
-  addToMap(test_map, (OBObjType *)a, NULL); /* remove binding of a -> b */
+  test = (OBTest *)OBMapGetValueForKey(test_map, (OBObjType *)a);
+  OBMapAdd(test_map, (OBObjType *)a, NULL); /* remove binding of a -> b */
 
-  assert(lookupMapKey(test_map, (OBObjType *)a) == NULL);
+  assert(OBMapGetValueForKey(test_map, (OBObjType *)a) == NULL);
   assert(OBReferenceCount((OBObjType *)test) == 1);
   
-  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)h);
+  test = (OBTest *)OBMapGetValueForKey(test_map, (OBObjType *)h);
   assert(OBCompare((OBObjType *)f, (OBObjType *)test) == OB_EQUAL_TO);
 
-  map_copy = copyMap(test_map);
-  addToMap(test_map, (OBObjType *)e, NULL); /* remove binding of e -> c */
-  test = (OBTest *)lookupMapKey(map_copy, (OBObjType *)e);
+  map_copy = OBMapCopy(test_map);
+  OBMapAdd(test_map, (OBObjType *)e, NULL); /* remove binding of e -> c */
+  test = (OBTest *)OBMapGetValueForKey(map_copy, (OBObjType *)e);
 
   assert(OBCompare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
   
-  removeMapKey(test_map, (OBObjType *)e);
-  test = (OBTest *)lookupMapKey(map_copy, (OBObjType *)e);
+  OBMapRemoveKey(test_map, (OBObjType *)e);
+  test = (OBTest *)OBMapGetValueForKey(map_copy, (OBObjType *)e);
 
   assert(OBCompare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
 
-  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)e);
+  test = (OBTest *)OBMapGetValueForKey(test_map, (OBObjType *)e);
 
   assert(test == NULL);
 
   assert(OBHash((OBObjType *)test_map) != OBHash((OBObjType *)map_copy));
   assert(OBCompare((OBObjType *)test_map, (OBObjType *)map_copy) != OB_EQUAL_TO);
 
-  addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
+  OBMapAdd(test_map, (OBObjType *)e, (OBObjType *)c);
 
   assert(OBHash((OBObjType *)test_map) == OBHash((OBObjType *)map_copy));
   assert(OBCompare((OBObjType *)test_map, (OBObjType *)map_copy) == OB_EQUAL_TO);
 
-  clearMap(map_copy);
+  OBMapClear(map_copy);
 
-  assert(lookupMapKey(map_copy, (OBObjType *)e) == NULL);
-  assert(lookupMapKey(map_copy, (OBObjType *)a) == NULL);
-  assert(lookupMapKey(map_copy, (OBObjType *)f) == NULL);
+  assert(OBMapGetValueForKey(map_copy, (OBObjType *)e) == NULL);
+  assert(OBMapGetValueForKey(map_copy, (OBObjType *)a) == NULL);
+  assert(OBMapGetValueForKey(map_copy, (OBObjType *)f) == NULL);
 
   for(i=0; i<ARRAY_SIZE; i++){
-    test_array[i] = createTest(i);
-    addToMap(test_map, (OBObjType *)test_array[i], (OBObjType *)test_array[i]);
+    test_array[i] = OBTestCreate(i);
+    OBMapAdd(test_map, (OBObjType *)test_array[i], (OBObjType *)test_array[i]);
   }
 
   for(i=0; i<ARRAY_SIZE; i++)
     assert(OBCompare((OBObjType *) test_array[i], 
-                   lookupMapKey(test_map, (OBObjType *)test_array[i])) ==OB_EQUAL_TO);
+                   OBMapGetValueForKey(test_map, (OBObjType *)test_array[i])) ==OB_EQUAL_TO);
 
   OBRelease((OBObjType *)a);
   OBRelease((OBObjType *)b);

--- a/src/tests/OBMap_test.c
+++ b/src/tests/OBMap_test.c
@@ -43,7 +43,7 @@ int main (){
 
   assert(test);
   assert(compare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
-  assert(referenceCount((OBObjType *)test) > 1);
+  assert(OBReferenceCount((OBObjType *)test) > 1);
 
   addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
   addToMap(test_map, (OBObjType *)f, (OBObjType *)d);
@@ -63,7 +63,7 @@ int main (){
   addToMap(test_map, (OBObjType *)a, NULL); /* remove binding of a -> b */
 
   assert(lookupMapKey(test_map, (OBObjType *)a) == NULL);
-  assert(referenceCount((OBObjType *)test) == 1);
+  assert(OBReferenceCount((OBObjType *)test) == 1);
   
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)h);
   assert(compare((OBObjType *)f, (OBObjType *)test) == OB_EQUAL_TO);
@@ -106,20 +106,20 @@ int main (){
     assert(compare((OBObjType *) test_array[i], 
                    lookupMapKey(test_map, (OBObjType *)test_array[i])) ==OB_EQUAL_TO);
 
-  release((OBObjType *)a);
-  release((OBObjType *)b);
-  release((OBObjType *)c);
-  release((OBObjType *)d);
-  release((OBObjType *)e);
-  release((OBObjType *)f);
-  release((OBObjType *)g);
-  release((OBObjType *)h);
+  OBRelease((OBObjType *)a);
+  OBRelease((OBObjType *)b);
+  OBRelease((OBObjType *)c);
+  OBRelease((OBObjType *)d);
+  OBRelease((OBObjType *)e);
+  OBRelease((OBObjType *)f);
+  OBRelease((OBObjType *)g);
+  OBRelease((OBObjType *)h);
 
-  release((OBObjType *)test_map);
-  release((OBObjType *)map_copy);
+  OBRelease((OBObjType *)test_map);
+  OBRelease((OBObjType *)map_copy);
 
   for(i=0; i<ARRAY_SIZE; i++)
-    release((OBObjType *)test_array[i]);
+    OBRelease((OBObjType *)test_array[i]);
     
   printf("OBMap_test: TESTS PASSED\n");
 

--- a/src/tests/OBMap_test.c
+++ b/src/tests/OBMap_test.c
@@ -34,92 +34,92 @@ int main (){
   g = createTest(1+3*MAP_CAPACITIES[0]);
   h = createTest(1+4*MAP_CAPACITIES[0]);
 
-  assert(hash((obj *)a)%MAP_CAPACITIES[0] == hash((obj *)e)%MAP_CAPACITIES[0]);
+  assert(hash((OBObjType *)a)%MAP_CAPACITIES[0] == hash((OBObjType *)e)%MAP_CAPACITIES[0]);
 
-  assert(lookupMapKey(test_map, (obj *)a) == NULL);
+  assert(lookupMapKey(test_map, (OBObjType *)a) == NULL);
 
-  addToMap(test_map, (obj *)a, (obj *)b);
-  test = (OBTest *)lookupMapKey(test_map, (obj *)a);
+  addToMap(test_map, (OBObjType *)a, (OBObjType *)b);
+  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
 
   assert(test);
-  assert(compare((obj *)b, (obj *)test) == OB_EQUAL_TO);
-  assert(referenceCount((obj *)test) > 1);
+  assert(compare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(referenceCount((OBObjType *)test) > 1);
 
-  addToMap(test_map, (obj *)e, (obj *)c);
-  addToMap(test_map, (obj *)f, (obj *)d);
-  addToMap(test_map, (obj *)g, (obj *)e);
-  addToMap(test_map, (obj *)h, (obj *)f);
-  test = (OBTest *)lookupMapKey(test_map, (obj *)a);
+  addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
+  addToMap(test_map, (OBObjType *)f, (OBObjType *)d);
+  addToMap(test_map, (OBObjType *)g, (OBObjType *)e);
+  addToMap(test_map, (OBObjType *)h, (OBObjType *)f);
+  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
 
-  assert(compare((obj *)b, (obj *)test) == OB_EQUAL_TO);
-  assert(compare((obj *)c, (obj *)test) != OB_EQUAL_TO);
+  assert(compare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(compare((OBObjType *)c, (OBObjType *)test) != OB_EQUAL_TO);
 
-  test = (OBTest *)lookupMapKey(test_map, (obj *)e);
+  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)e);
   
-  assert(compare((obj *)c, (obj *)test) == OB_EQUAL_TO);
-  assert(compare((obj *)b, (obj *)test) != OB_EQUAL_TO);
+  assert(compare((OBObjType *)c, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(compare((OBObjType *)b, (OBObjType *)test) != OB_EQUAL_TO);
   
-  test = (OBTest *)lookupMapKey(test_map, (obj *)a);
-  addToMap(test_map, (obj *)a, NULL); /* remove binding of a -> b */
+  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
+  addToMap(test_map, (OBObjType *)a, NULL); /* remove binding of a -> b */
 
-  assert(lookupMapKey(test_map, (obj *)a) == NULL);
-  assert(referenceCount((obj *)test) == 1);
+  assert(lookupMapKey(test_map, (OBObjType *)a) == NULL);
+  assert(referenceCount((OBObjType *)test) == 1);
   
-  test = (OBTest *)lookupMapKey(test_map, (obj *)h);
-  assert(compare((obj *)f, (obj *)test) == OB_EQUAL_TO);
+  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)h);
+  assert(compare((OBObjType *)f, (OBObjType *)test) == OB_EQUAL_TO);
 
   map_copy = copyMap(test_map);
-  addToMap(test_map, (obj *)e, NULL); /* remove binding of e -> c */
-  test = (OBTest *)lookupMapKey(map_copy, (obj *)e);
+  addToMap(test_map, (OBObjType *)e, NULL); /* remove binding of e -> c */
+  test = (OBTest *)lookupMapKey(map_copy, (OBObjType *)e);
 
-  assert(compare((obj *)test, (obj *)c) == OB_EQUAL_TO);
+  assert(compare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
   
-  removeMapKey(test_map, (obj *)e);
-  test = (OBTest *)lookupMapKey(map_copy, (obj *)e);
+  removeMapKey(test_map, (OBObjType *)e);
+  test = (OBTest *)lookupMapKey(map_copy, (OBObjType *)e);
 
-  assert(compare((obj *)test, (obj *)c) == OB_EQUAL_TO);
+  assert(compare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
 
-  test = (OBTest *)lookupMapKey(test_map, (obj *)e);
+  test = (OBTest *)lookupMapKey(test_map, (OBObjType *)e);
 
   assert(test == NULL);
 
-  assert(hash((obj *)test_map) != hash((obj *)map_copy));
-  assert(compare((obj *)test_map, (obj *)map_copy) != OB_EQUAL_TO);
+  assert(hash((OBObjType *)test_map) != hash((OBObjType *)map_copy));
+  assert(compare((OBObjType *)test_map, (OBObjType *)map_copy) != OB_EQUAL_TO);
 
-  addToMap(test_map, (obj *)e, (obj *)c);
+  addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
 
-  assert(hash((obj *)test_map) == hash((obj *)map_copy));
-  assert(compare((obj *)test_map, (obj *)map_copy) == OB_EQUAL_TO);
+  assert(hash((OBObjType *)test_map) == hash((OBObjType *)map_copy));
+  assert(compare((OBObjType *)test_map, (OBObjType *)map_copy) == OB_EQUAL_TO);
 
   clearMap(map_copy);
 
-  assert(lookupMapKey(map_copy, (obj *)e) == NULL);
-  assert(lookupMapKey(map_copy, (obj *)a) == NULL);
-  assert(lookupMapKey(map_copy, (obj *)f) == NULL);
+  assert(lookupMapKey(map_copy, (OBObjType *)e) == NULL);
+  assert(lookupMapKey(map_copy, (OBObjType *)a) == NULL);
+  assert(lookupMapKey(map_copy, (OBObjType *)f) == NULL);
 
   for(i=0; i<ARRAY_SIZE; i++){
     test_array[i] = createTest(i);
-    addToMap(test_map, (obj *)test_array[i], (obj *)test_array[i]);
+    addToMap(test_map, (OBObjType *)test_array[i], (OBObjType *)test_array[i]);
   }
 
   for(i=0; i<ARRAY_SIZE; i++)
-    assert(compare((obj *) test_array[i], 
-                   lookupMapKey(test_map, (obj *)test_array[i])) ==OB_EQUAL_TO);
+    assert(compare((OBObjType *) test_array[i], 
+                   lookupMapKey(test_map, (OBObjType *)test_array[i])) ==OB_EQUAL_TO);
 
-  release((obj *)a);
-  release((obj *)b);
-  release((obj *)c);
-  release((obj *)d);
-  release((obj *)e);
-  release((obj *)f);
-  release((obj *)g);
-  release((obj *)h);
+  release((OBObjType *)a);
+  release((OBObjType *)b);
+  release((OBObjType *)c);
+  release((OBObjType *)d);
+  release((OBObjType *)e);
+  release((OBObjType *)f);
+  release((OBObjType *)g);
+  release((OBObjType *)h);
 
-  release((obj *)test_map);
-  release((obj *)map_copy);
+  release((OBObjType *)test_map);
+  release((OBObjType *)map_copy);
 
   for(i=0; i<ARRAY_SIZE; i++)
-    release((obj *)test_array[i]);
+    release((OBObjType *)test_array[i]);
     
   printf("OBMap_test: TESTS PASSED\n");
 

--- a/src/tests/OBMap_test.c
+++ b/src/tests/OBMap_test.c
@@ -34,7 +34,7 @@ int main (){
   g = createTest(1+3*MAP_CAPACITIES[0]);
   h = createTest(1+4*MAP_CAPACITIES[0]);
 
-  assert(hash((OBObjType *)a)%MAP_CAPACITIES[0] == hash((OBObjType *)e)%MAP_CAPACITIES[0]);
+  assert(OBHash((OBObjType *)a)%MAP_CAPACITIES[0] == OBHash((OBObjType *)e)%MAP_CAPACITIES[0]);
 
   assert(lookupMapKey(test_map, (OBObjType *)a) == NULL);
 
@@ -42,7 +42,7 @@ int main (){
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
 
   assert(test);
-  assert(compare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
   assert(OBReferenceCount((OBObjType *)test) > 1);
 
   addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
@@ -51,13 +51,13 @@ int main (){
   addToMap(test_map, (OBObjType *)h, (OBObjType *)f);
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
 
-  assert(compare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
-  assert(compare((OBObjType *)c, (OBObjType *)test) != OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)b, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)c, (OBObjType *)test) != OB_EQUAL_TO);
 
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)e);
   
-  assert(compare((OBObjType *)c, (OBObjType *)test) == OB_EQUAL_TO);
-  assert(compare((OBObjType *)b, (OBObjType *)test) != OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)c, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)b, (OBObjType *)test) != OB_EQUAL_TO);
   
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)a);
   addToMap(test_map, (OBObjType *)a, NULL); /* remove binding of a -> b */
@@ -66,30 +66,30 @@ int main (){
   assert(OBReferenceCount((OBObjType *)test) == 1);
   
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)h);
-  assert(compare((OBObjType *)f, (OBObjType *)test) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)f, (OBObjType *)test) == OB_EQUAL_TO);
 
   map_copy = copyMap(test_map);
   addToMap(test_map, (OBObjType *)e, NULL); /* remove binding of e -> c */
   test = (OBTest *)lookupMapKey(map_copy, (OBObjType *)e);
 
-  assert(compare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
   
   removeMapKey(test_map, (OBObjType *)e);
   test = (OBTest *)lookupMapKey(map_copy, (OBObjType *)e);
 
-  assert(compare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)test, (OBObjType *)c) == OB_EQUAL_TO);
 
   test = (OBTest *)lookupMapKey(test_map, (OBObjType *)e);
 
   assert(test == NULL);
 
-  assert(hash((OBObjType *)test_map) != hash((OBObjType *)map_copy));
-  assert(compare((OBObjType *)test_map, (OBObjType *)map_copy) != OB_EQUAL_TO);
+  assert(OBHash((OBObjType *)test_map) != OBHash((OBObjType *)map_copy));
+  assert(OBCompare((OBObjType *)test_map, (OBObjType *)map_copy) != OB_EQUAL_TO);
 
   addToMap(test_map, (OBObjType *)e, (OBObjType *)c);
 
-  assert(hash((OBObjType *)test_map) == hash((OBObjType *)map_copy));
-  assert(compare((OBObjType *)test_map, (OBObjType *)map_copy) == OB_EQUAL_TO);
+  assert(OBHash((OBObjType *)test_map) == OBHash((OBObjType *)map_copy));
+  assert(OBCompare((OBObjType *)test_map, (OBObjType *)map_copy) == OB_EQUAL_TO);
 
   clearMap(map_copy);
 
@@ -103,7 +103,7 @@ int main (){
   }
 
   for(i=0; i<ARRAY_SIZE; i++)
-    assert(compare((OBObjType *) test_array[i], 
+    assert(OBCompare((OBObjType *) test_array[i], 
                    lookupMapKey(test_map, (OBObjType *)test_array[i])) ==OB_EQUAL_TO);
 
   OBRelease((OBObjType *)a);

--- a/src/tests/OBString_test.c
+++ b/src/tests/OBString_test.c
@@ -29,19 +29,19 @@ int main (){
   contents = getCString(str2);
   assert(strcmp(contents, "Hello") == 0);
 
-  release((obj *)str2);
+  release((OBObjType *)str2);
 
   str2 = copySubstring(str1, -15, 7);
   contents = getCString(str2);
   assert(strcmp(contents, "Hello") == 0);
 
-  release((obj *)str2);
+  release((OBObjType *)str2);
 
   str2 = copySubstring(str1, 0, stringLength(str1));
   contents = getCString(str2);
   assert(strcmp(contents, "Hello, World!") == 0);
 
-  release((obj *)str2);
+  release((OBObjType *)str2);
 
   null_str = copySubstring(str1, 20, 2);
   assert(stringLength(null_str) == 0);
@@ -59,19 +59,19 @@ int main (){
   contents = getCString(str3);
   assert(strcmp(contents, "Hello, World! And hello again!") == 0);
 
-  release((obj *)str2);
+  release((OBObjType *)str2);
 
   str2 = concatenateStrings(null_str, str1);
   contents = getCString(str2);
   assert(strcmp(contents, "Hello, World!") == 0);
 
   /* Test String Comparision */
-  assert(compare((obj *)str1, (obj *)str2) == OB_EQUAL_TO);
-  assert(compare((obj *)str1, (obj *)str3) == OB_LESS_THAN);
-  assert(compare((obj *)str1, (obj *)null_str) == OB_GREATER_THAN);
+  assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
+  assert(compare((OBObjType *)str1, (OBObjType *)str3) == OB_LESS_THAN);
+  assert(compare((OBObjType *)str1, (OBObjType *)null_str) == OB_GREATER_THAN);
 
-  release((obj *)str2);
-  release((obj *)str3);
+  release((OBObjType *)str2);
+  release((OBObjType *)str3);
 
   /* Test String Splits */
   str2 = createString("Testing string split   into#!many");
@@ -81,7 +81,7 @@ int main (){
   assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 3)),
                            "into#!many") == 0);
 
-  release((obj *)tokens);
+  release((OBObjType *)tokens);
 
   tokens = splitString(str2, "#!");
   assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 0)),
@@ -89,7 +89,7 @@ int main (){
   assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 1)), "many")
          == 0);
 
-  release((obj *)tokens);
+  release((OBObjType *)tokens);
 
   /* Test String Search */
 
@@ -100,15 +100,15 @@ int main (){
   /* Test Regex Match */
   str3 = matchStringRegex(str1, "[Hh]el{1,2}.");
   assert(strcmp(getCString(str3), "Hello") == 0);
-  release((obj *)str3);
+  release((OBObjType *)str3);
 
   str3 = matchStringRegex(str2, " *into[#!]{2,2}.*$");
   assert(strcmp(getCString(str3), "   into#!many") == 0);
 
-  release((obj *)str3);
-  release((obj *)str2);
-  release((obj *)str1);
-  release((obj *)null_str);
+  release((OBObjType *)str3);
+  release((OBObjType *)str2);
+  release((OBObjType *)str1);
+  release((OBObjType *)null_str);
     
   /* TESTS COMPLETE */
   printf("OBString_test: TESTS PASSED\n");

--- a/src/tests/OBString_test.c
+++ b/src/tests/OBString_test.c
@@ -66,9 +66,9 @@ int main (){
   assert(strcmp(contents, "Hello, World!") == 0);
 
   /* Test String Comparision */
-  assert(compare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
-  assert(compare((OBObjType *)str1, (OBObjType *)str3) == OB_LESS_THAN);
-  assert(compare((OBObjType *)str1, (OBObjType *)null_str) == OB_GREATER_THAN);
+  assert(OBCompare((OBObjType *)str1, (OBObjType *)str2) == OB_EQUAL_TO);
+  assert(OBCompare((OBObjType *)str1, (OBObjType *)str3) == OB_LESS_THAN);
+  assert(OBCompare((OBObjType *)str1, (OBObjType *)null_str) == OB_GREATER_THAN);
 
   OBRelease((OBObjType *)str2);
   OBRelease((OBObjType *)str3);

--- a/src/tests/OBString_test.c
+++ b/src/tests/OBString_test.c
@@ -29,19 +29,19 @@ int main (){
   contents = getCString(str2);
   assert(strcmp(contents, "Hello") == 0);
 
-  release((OBObjType *)str2);
+  OBRelease((OBObjType *)str2);
 
   str2 = copySubstring(str1, -15, 7);
   contents = getCString(str2);
   assert(strcmp(contents, "Hello") == 0);
 
-  release((OBObjType *)str2);
+  OBRelease((OBObjType *)str2);
 
   str2 = copySubstring(str1, 0, stringLength(str1));
   contents = getCString(str2);
   assert(strcmp(contents, "Hello, World!") == 0);
 
-  release((OBObjType *)str2);
+  OBRelease((OBObjType *)str2);
 
   null_str = copySubstring(str1, 20, 2);
   assert(stringLength(null_str) == 0);
@@ -59,7 +59,7 @@ int main (){
   contents = getCString(str3);
   assert(strcmp(contents, "Hello, World! And hello again!") == 0);
 
-  release((OBObjType *)str2);
+  OBRelease((OBObjType *)str2);
 
   str2 = concatenateStrings(null_str, str1);
   contents = getCString(str2);
@@ -70,8 +70,8 @@ int main (){
   assert(compare((OBObjType *)str1, (OBObjType *)str3) == OB_LESS_THAN);
   assert(compare((OBObjType *)str1, (OBObjType *)null_str) == OB_GREATER_THAN);
 
-  release((OBObjType *)str2);
-  release((OBObjType *)str3);
+  OBRelease((OBObjType *)str2);
+  OBRelease((OBObjType *)str3);
 
   /* Test String Splits */
   str2 = createString("Testing string split   into#!many");
@@ -81,7 +81,7 @@ int main (){
   assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 3)),
                            "into#!many") == 0);
 
-  release((OBObjType *)tokens);
+  OBRelease((OBObjType *)tokens);
 
   tokens = splitString(str2, "#!");
   assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 0)),
@@ -89,7 +89,7 @@ int main (){
   assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 1)), "many")
          == 0);
 
-  release((OBObjType *)tokens);
+  OBRelease((OBObjType *)tokens);
 
   /* Test String Search */
 
@@ -100,15 +100,15 @@ int main (){
   /* Test Regex Match */
   str3 = matchStringRegex(str1, "[Hh]el{1,2}.");
   assert(strcmp(getCString(str3), "Hello") == 0);
-  release((OBObjType *)str3);
+  OBRelease((OBObjType *)str3);
 
   str3 = matchStringRegex(str2, " *into[#!]{2,2}.*$");
   assert(strcmp(getCString(str3), "   into#!many") == 0);
 
-  release((OBObjType *)str3);
-  release((OBObjType *)str2);
-  release((OBObjType *)str1);
-  release((OBObjType *)null_str);
+  OBRelease((OBObjType *)str3);
+  OBRelease((OBObjType *)str2);
+  OBRelease((OBObjType *)str1);
+  OBRelease((OBObjType *)null_str);
     
   /* TESTS COMPLETE */
   printf("OBString_test: TESTS PASSED\n");

--- a/src/tests/OBString_test.c
+++ b/src/tests/OBString_test.c
@@ -17,52 +17,52 @@ int main (){
   OBVector *tokens;
   const char *contents;
 
-  str1 = createString("Hello, World!");
+  str1 = OBStringCreate("Hello, World!");
 
   /* Test createString and getCString */
-  contents = getCString(str1);
+  contents = OBStringGetCString(str1);
   assert(strcmp(contents, "Hello, World!") == 0);
   
 
   /* Test copySubstring and stringLength */
-  str2 = copySubstring(str1, 0, 5);
-  contents = getCString(str2);
+  str2 = OBStringGetSubstringCopyRange(str1, 0, 5);
+  contents = OBStringGetCString(str2);
   assert(strcmp(contents, "Hello") == 0);
 
   OBRelease((OBObjType *)str2);
 
-  str2 = copySubstring(str1, -15, 7);
-  contents = getCString(str2);
+  str2 = OBStringGetSubstringCopyRange(str1, -15, 7);
+  contents = OBStringGetCString(str2);
   assert(strcmp(contents, "Hello") == 0);
 
   OBRelease((OBObjType *)str2);
 
-  str2 = copySubstring(str1, 0, stringLength(str1));
-  contents = getCString(str2);
+  str2 = OBStringGetSubstringCopyRange(str1, 0, OBStringGetLength(str1));
+  contents = OBStringGetCString(str2);
   assert(strcmp(contents, "Hello, World!") == 0);
 
   OBRelease((OBObjType *)str2);
 
-  null_str = copySubstring(str1, 20, 2);
-  assert(stringLength(null_str) == 0);
+  null_str = OBStringGetSubstringCopyRange(str1, 20, 2);
+  assert(OBStringGetLength(null_str) == 0);
 
   /* Test charAtStringIndex */
-  assert(charAtStringIndex(str1, 0) == 'H');
-  assert(charAtStringIndex(str1, -5) == 'o');
-  assert(charAtStringIndex(str1, -20) == '\0');
-  assert(charAtStringIndex(str1, 20) == '\0');
-  assert(charAtStringIndex(null_str, 0) == '\0');
+  assert(OBStringGetCharAtIndex(str1, 0) == 'H');
+  assert(OBStringGetCharAtIndex(str1, -5) == 'o');
+  assert(OBStringGetCharAtIndex(str1, -20) == '\0');
+  assert(OBStringGetCharAtIndex(str1, 20) == '\0');
+  assert(OBStringGetCharAtIndex(null_str, 0) == '\0');
 
   /* Test String Concatenation */
-  str2 = createString(" And hello again!");
-  str3 = concatenateStrings(str1, str2);
-  contents = getCString(str3);
+  str2 = OBStringCreate(" And hello again!");
+  str3 = OBStringConcatenate(str1, str2);
+  contents = OBStringGetCString(str3);
   assert(strcmp(contents, "Hello, World! And hello again!") == 0);
 
   OBRelease((OBObjType *)str2);
 
-  str2 = concatenateStrings(null_str, str1);
-  contents = getCString(str2);
+  str2 = OBStringConcatenate(null_str, str1);
+  contents = OBStringGetCString(str2);
   assert(strcmp(contents, "Hello, World!") == 0);
 
   /* Test String Comparision */
@@ -74,36 +74,36 @@ int main (){
   OBRelease((OBObjType *)str3);
 
   /* Test String Splits */
-  str2 = createString("Testing string split   into#!many");
-  tokens = splitString(str2, " ");
-  assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 0)), "Testing")
+  str2 = OBStringCreate("Testing string split   into#!many");
+  tokens = OBStringComponentsSeparatedBy(str2, " ");
+  assert(strcmp(OBStringGetCString((OBString *)OBVectorObjectAtIndex(tokens, 0)), "Testing")
          == 0);
-  assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 3)),
+  assert(strcmp(OBStringGetCString((OBString *)OBVectorObjectAtIndex(tokens, 3)),
                            "into#!many") == 0);
 
   OBRelease((OBObjType *)tokens);
 
-  tokens = splitString(str2, "#!");
-  assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 0)),
+  tokens = OBStringComponentsSeparatedBy(str2, "#!");
+  assert(strcmp(OBStringGetCString((OBString *)OBVectorObjectAtIndex(tokens, 0)),
                            "Testing string split   into") == 0);
-  assert(strcmp(getCString((OBString *)objAtVectorIndex(tokens, 1)), "many")
+  assert(strcmp(OBStringGetCString((OBString *)OBVectorObjectAtIndex(tokens, 1)), "many")
          == 0);
 
   OBRelease((OBObjType *)tokens);
 
   /* Test String Search */
 
-  assert(findSubstring(str2, "Testing") != 0);
-  assert(findSubstring(str2, "#!many") != 0);
-  assert(findSubstring(str2, "Hello World") == 0);
+  assert(OBStringContains(str2, "Testing") != 0);
+  assert(OBStringContains(str2, "#!many") != 0);
+  assert(OBStringContains(str2, "Hello World") == 0);
 
   /* Test Regex Match */
-  str3 = matchStringRegex(str1, "[Hh]el{1,2}.");
-  assert(strcmp(getCString(str3), "Hello") == 0);
+  str3 = OBStringMatchRegex(str1, "[Hh]el{1,2}.");
+  assert(strcmp(OBStringGetCString(str3), "Hello") == 0);
   OBRelease((OBObjType *)str3);
 
-  str3 = matchStringRegex(str2, " *into[#!]{2,2}.*$");
-  assert(strcmp(getCString(str3), "   into#!many") == 0);
+  str3 = OBStringMatchRegex(str2, " *into[#!]{2,2}.*$");
+  assert(strcmp(OBStringGetCString(str3), "   into#!many") == 0);
 
   OBRelease((OBObjType *)str3);
   OBRelease((OBObjType *)str2);

--- a/src/tests/OBTest_test.c
+++ b/src/tests/OBTest_test.c
@@ -14,9 +14,9 @@ int main(){
 
   int i;
   OBTest *test_obj, *a, *b;
-  test_obj = createTest(1);
-  a = createTest(3);
-  b = createTest(3);
+  test_obj = OBTestCreate(1);
+  a = OBTestCreate(3);
+  b = OBTestCreate(3);
 
   /* retain object, reference count should be 4 */
   for(i=0; i<3; i++){

--- a/src/tests/OBTest_test.c
+++ b/src/tests/OBTest_test.c
@@ -45,19 +45,19 @@ int main(){
     exit(1);
 	}
 
-  if(!sameClass((OBObjType *)a, (OBObjType *)b)){
+  if(!OBObjectsHaveSameClass((OBObjType *)a, (OBObjType *)b)){
     fprintf(stderr, "OBTest_test: Two OBTest objects were not of the same "
                     "class, TEST FAILED\n");
     exit(1);
   }
 
-  if(!objIsOfClass((OBObjType *)a, "OBTest")){
+  if(!OBObjIsOfClass((OBObjType *)a, "OBTest")){
     fprintf(stderr, "OBTest_test: An OBTest object was not considered to be an "
                     "OBTest object during check, TEST FAILED\n");
     exit(1);
   }
 
-  hash((OBObjType *)a);
+  OBHash((OBObjType *)a);
 
   printf("OBTest_test: TEST PASSED\n");
   return 0;

--- a/src/tests/OBTest_test.c
+++ b/src/tests/OBTest_test.c
@@ -20,10 +20,10 @@ int main(){
 
   /* retain object, reference count should be 4 */
   for(i=0; i<3; i++){
-    retain((obj *)test_obj);
+    retain((OBObjType *)test_obj);
   }
 
-  if(referenceCount((obj *)test_obj) != 4){
+  if(referenceCount((OBObjType *)test_obj) != 4){
     fprintf(stderr, "OBTest_test: reference count not incrememted correctly by "
                     "retain\nTEST FAILED\n");
     exit(1);
@@ -32,7 +32,7 @@ int main(){
   /* release object until test_obj is deallocated or until release has been
    * called more than 4 times */
   i=0;
-  while(++i < 5 && release((obj *)test_obj) != NULL){}
+  while(++i < 5 && release((OBObjType *)test_obj) != NULL){}
 
   if(i<4){
     fprintf(stderr, "OBTest_test: test_obj released before reference count "
@@ -45,19 +45,19 @@ int main(){
     exit(1);
 	}
 
-  if(!sameClass((obj *)a, (obj *)b)){
+  if(!sameClass((OBObjType *)a, (OBObjType *)b)){
     fprintf(stderr, "OBTest_test: Two OBTest objects were not of the same "
                     "class, TEST FAILED\n");
     exit(1);
   }
 
-  if(!objIsOfClass((obj *)a, "OBTest")){
+  if(!objIsOfClass((OBObjType *)a, "OBTest")){
     fprintf(stderr, "OBTest_test: An OBTest object was not considered to be an "
                     "OBTest object during check, TEST FAILED\n");
     exit(1);
   }
 
-  hash((obj *)a);
+  hash((OBObjType *)a);
 
   printf("OBTest_test: TEST PASSED\n");
   return 0;

--- a/src/tests/OBTest_test.c
+++ b/src/tests/OBTest_test.c
@@ -20,10 +20,10 @@ int main(){
 
   /* retain object, reference count should be 4 */
   for(i=0; i<3; i++){
-    retain((OBObjType *)test_obj);
+    OBRetain((OBObjType *)test_obj);
   }
 
-  if(referenceCount((OBObjType *)test_obj) != 4){
+  if(OBReferenceCount((OBObjType *)test_obj) != 4){
     fprintf(stderr, "OBTest_test: reference count not incrememted correctly by "
                     "retain\nTEST FAILED\n");
     exit(1);
@@ -32,7 +32,7 @@ int main(){
   /* release object until test_obj is deallocated or until release has been
    * called more than 4 times */
   i=0;
-  while(++i < 5 && release((OBObjType *)test_obj) != NULL){}
+  while(++i < 5 && OBRelease((OBObjType *)test_obj) != NULL){}
 
   if(i<4){
     fprintf(stderr, "OBTest_test: test_obj released before reference count "

--- a/src/tests/OBVector_test.c
+++ b/src/tests/OBVector_test.c
@@ -17,12 +17,12 @@ int main(){
   OBTest *tests[6], *singleton, *tmp;
   OBVector *main_vec, *copy_vec;
 
-  main_vec = createVector(1);
-  singleton = createTest(7);
+  main_vec = OBVectorCreateWithCapacity(1);
+  singleton = OBTestCreate(7);
 
   for(i=0; i<6; i++){
-    tests[i] = createTest(i);
-    storeAtVectorIndex(main_vec, (OBObjType *)tests[i], i);
+    tests[i] = OBTestCreate(i);
+    OBVectorStoreAtIndex(main_vec, (OBObjType *)tests[i], i);
 
     if(OBReferenceCount((OBObjType *)tests[i]) != 2){
       fprintf(stderr, "OBVector_test: vector did not properly retain element "
@@ -33,13 +33,13 @@ int main(){
     OBRelease((OBObjType *)tests[i]); /* vector should maintain only references */
   }
 
-  if(vectorLength(main_vec) != 6){
+  if(OBVectorGetLength(main_vec) != 6){
     fprintf(stderr, "OBVector_test: vector size is off, TEST FAILED\n");
     exit(1);
   }
 
   for(i=0; i<6; i++){
-    if(getTestID((OBTest *)objAtVectorIndex(main_vec,i)) != i){
+    if(OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec,i)) != i){
       fprintf(stderr, "OBVector_test: vector does not contain added contents "
                       "in expected order\nTEST FAILED\n");
       printf("%d\n", i);
@@ -47,16 +47,16 @@ int main(){
     }
   }
 
-  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 12);
-  if(vectorLength(main_vec) != 13){
+  OBVectorStoreAtIndex(main_vec, (OBObjType *)singleton, 12);
+  if(OBVectorGetLength(main_vec) != 13){
     fprintf(stderr, "OBVector_test: store did not properly extend length "
                     "TEST FAILED\n");
     exit(1);
   }
 
 
-  storeAtVectorIndex(main_vec, NULL, 12);
-  if(vectorLength(main_vec) != 6){
+  OBVectorStoreAtIndex(main_vec, NULL, 12);
+  if(OBVectorGetLength(main_vec) != 6){
     fprintf(stderr, "OBVector_test: remove did not properly get rid of element "
                     "TEST FAILED\n");
     exit(1);
@@ -68,86 +68,86 @@ int main(){
     exit(1);
   }
 
-  tmp = (OBTest *)objAtVectorIndex(main_vec, 3);
+  tmp = (OBTest *)OBVectorObjectAtIndex(main_vec, 3);
   OBRetain((OBObjType *)tmp);
 
-  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 3);
+  OBVectorStoreAtIndex(main_vec, (OBObjType *)singleton, 3);
   if(OBReferenceCount((OBObjType *)tmp) != 1){
     fprintf(stderr, "OBVector_test: vector did not release element on "
                     "replacement, TEST FAILED\n");
     exit(1);
   }
 
-  if(vectorLength(main_vec) != 6 ||
-     getTestID((OBTest *)objAtVectorIndex(main_vec, 3)) != 
-     getTestID(singleton)){
+  if(OBVectorGetLength(main_vec) != 6 ||
+     OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec, 3)) != 
+     OBTestGetID(singleton)){
     fprintf(stderr, "OBVector_test: element was not added properly to vector "
                     "at index\nTEST FAILED\n");
     exit(1);
   }
 
-  storeAtVectorIndex(main_vec, (OBObjType *)tmp, 3);
+  OBVectorStoreAtIndex(main_vec, (OBObjType *)tmp, 3);
 
   /* reduce reference count to 1, so only vector holds reference to obj */
   OBRelease((OBObjType *)tmp);
 
-  if(findObjInVector(main_vec, (OBObjType *)singleton)){
+  if(OBVectorContains(main_vec, (OBObjType *)singleton)){
     fprintf(stderr, "OBVector_test: vector did not replace element correctly, "
                     "or was not found\nTEST FAILED\n");
     exit(1);
   }
   
-  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 10);
-  if(vectorLength(main_vec) != 11){
+  OBVectorStoreAtIndex(main_vec, (OBObjType *)singleton, 10);
+  if(OBVectorGetLength(main_vec) != 11){
     fprintf(stderr, "OBVector_test: store did not properly extend length "
                     "TEST FAILED\n");
     exit(1);
   }
 
-  sortVector(main_vec, OB_LEAST_TO_GREATEST);
-  if(vectorLength(main_vec) != 7){
+  OBVectorSort(main_vec, OB_LEAST_TO_GREATEST);
+  if(OBVectorGetLength(main_vec) != 7){
     fprintf(stderr, "OBVector_test: sort did not properly remove NULLs "
                     "TEST FAILED\n");
     fprintf(stderr, "OBVector_test: vector size == %d\n", 
-                    vectorLength(main_vec));
-    for(i=0; i<vectorLength(main_vec); i++){
-      if(objAtVectorIndex(main_vec, i)) printf("object\n");
+                    OBVectorGetLength(main_vec));
+    for(i=0; i<OBVectorGetLength(main_vec); i++){
+      if(OBVectorObjectAtIndex(main_vec, i)) printf("object\n");
       else printf("NULL\n");
     }
     exit(1);
   }
 
   id = 0;
-  for(i=0; i<vectorLength(main_vec); i++){
-    if(id > getTestID((OBTest *)objAtVectorIndex(main_vec, i))){
+  for(i=0; i<OBVectorGetLength(main_vec); i++){
+    if(id > OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec, i))){
       fprintf(stderr, "OBVector_test: vector was not sorted least to "
                       "greatest, TEST FAILED\n");
       exit(1);
     }
-    id = getTestID((OBTest *)objAtVectorIndex(main_vec, i));
+    id = OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec, i));
   }
 
-  storeAtVectorIndex(main_vec, NULL, 6);
-  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 10);
+  OBVectorStoreAtIndex(main_vec, NULL, 6);
+  OBVectorStoreAtIndex(main_vec, (OBObjType *)singleton, 10);
 
-  sortVector(main_vec, OB_GREATEST_TO_LEAST);
-  if(vectorLength(main_vec) != 7){
+  OBVectorSort(main_vec, OB_GREATEST_TO_LEAST);
+  if(OBVectorGetLength(main_vec) != 7){
     fprintf(stderr, "OBVector_test: second sort did not properly remove NULLs "
                     "TEST FAILED\n");
     exit(1);
   }
 
   id = 10;
-  for(i=0; i<vectorLength(main_vec); i++){
-    if(id < getTestID((OBTest *)objAtVectorIndex(main_vec, i))){
+  for(i=0; i<OBVectorGetLength(main_vec); i++){
+    if(id < OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec, i))){
       fprintf(stderr, "OBVector_test: vector was not sorted greatest to "
                       "least, TEST FAILED\n");
       exit(1);
     }
-    id = getTestID((OBTest *)objAtVectorIndex(main_vec, i));
+    id = OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec, i));
   }
   
-  copy_vec = copyVector(main_vec);
+  copy_vec = OBVectorCopy(main_vec);
 
   assert(OBCompare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_EQUAL_TO);
   assert(OBHash((OBObjType *)copy_vec) == OBHash((OBObjType *)main_vec));
@@ -155,8 +155,8 @@ int main(){
   OBRelease((OBObjType *)singleton); /* release singleton once so it is only referenced
                                 by containing vectors */
 
-  for(i=0; i<vectorLength(main_vec); i++){
-    if(OBReferenceCount((OBObjType *)(OBTest *)objAtVectorIndex(main_vec, i)) != 2){
+  for(i=0; i<OBVectorGetLength(main_vec); i++){
+    if(OBReferenceCount((OBObjType *)(OBTest *)OBVectorObjectAtIndex(main_vec, i)) != 2){
       fprintf(stderr, "OBVector_test: vector contents not retained on copy, "
                       "TEST FAILED\n");
       exit(1);
@@ -164,28 +164,28 @@ int main(){
   }
   
   /* get obj at index and retain it so it isnt deallocated */
-  tmp = (OBTest *)objAtVectorIndex(main_vec, 3);
+  tmp = (OBTest *)OBVectorObjectAtIndex(main_vec, 3);
   OBRetain((OBObjType *)tmp);
 
-  storeAtVectorIndex(main_vec, NULL, 3);
+  OBVectorStoreAtIndex(main_vec, NULL, 3);
 
   assert(OBCompare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_NOT_EQUAL);
   assert(OBHash((OBObjType *)copy_vec) != OBHash((OBObjType *)main_vec));
 
-  if(findObjInVector(main_vec, (OBObjType *)tmp)){
+  if(OBVectorContains(main_vec, (OBObjType *)tmp)){
     fprintf(stderr, "OBVector_test: Item was not removed properly from vector"
                     "index, TEST FAILED\n");
     exit(1);
   }
 
-  storeAtVectorIndex(main_vec, (OBObjType *)tmp, 3);
-  assert(vectorLength(main_vec) == 7);
-  catVectors(main_vec, copy_vec);
-  assert(vectorLength(main_vec) == 14);
+  OBVectorStoreAtIndex(main_vec, (OBObjType *)tmp, 3);
+  assert(OBVectorGetLength(main_vec) == 7);
+  OBVectorConcatenateVector(main_vec, copy_vec);
+  assert(OBVectorGetLength(main_vec) == 14);
 
-  for(i=0; i<vectorLength(main_vec)/2; i++){
-    if(getTestID((OBTest *)objAtVectorIndex(main_vec,i)) !=
-       getTestID((OBTest *)objAtVectorIndex(main_vec,i+7))){
+  for(i=0; i<OBVectorGetLength(main_vec)/2; i++){
+    if(OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec,i)) !=
+       OBTestGetID((OBTest *)OBVectorObjectAtIndex(main_vec,i+7))){
       fprintf(stderr, "OBVector_test: Copy of vector not appended properly, "
                       "TEST FAILED\n");
       exit(1);

--- a/src/tests/OBVector_test.c
+++ b/src/tests/OBVector_test.c
@@ -22,15 +22,15 @@ int main(){
 
   for(i=0; i<6; i++){
     tests[i] = createTest(i);
-    storeAtVectorIndex(main_vec, (obj *)tests[i], i);
+    storeAtVectorIndex(main_vec, (OBObjType *)tests[i], i);
 
-    if(referenceCount((obj *)tests[i]) != 2){
+    if(referenceCount((OBObjType *)tests[i]) != 2){
       fprintf(stderr, "OBVector_test: vector did not properly retain element "
                       "TEST FAILED\n");
       exit(1);
     }
 
-    release((obj *)tests[i]); /* vector should maintain only references */
+    release((OBObjType *)tests[i]); /* vector should maintain only references */
   }
 
   if(vectorLength(main_vec) != 6){
@@ -47,7 +47,7 @@ int main(){
     }
   }
 
-  storeAtVectorIndex(main_vec, (obj *)singleton, 12);
+  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 12);
   if(vectorLength(main_vec) != 13){
     fprintf(stderr, "OBVector_test: store did not properly extend length "
                     "TEST FAILED\n");
@@ -62,17 +62,17 @@ int main(){
     exit(1);
   }
 
-  if(referenceCount((obj *)singleton) != 1){
+  if(referenceCount((OBObjType *)singleton) != 1){
     fprintf(stderr, "OBVector_test: vector did not release element on removal "
                     "TEST FAILED\n");
     exit(1);
   }
 
   tmp = (OBTest *)objAtVectorIndex(main_vec, 3);
-  retain((obj *)tmp);
+  retain((OBObjType *)tmp);
 
-  storeAtVectorIndex(main_vec, (obj *)singleton, 3);
-  if(referenceCount((obj *)tmp) != 1){
+  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 3);
+  if(referenceCount((OBObjType *)tmp) != 1){
     fprintf(stderr, "OBVector_test: vector did not release element on "
                     "replacement, TEST FAILED\n");
     exit(1);
@@ -86,18 +86,18 @@ int main(){
     exit(1);
   }
 
-  storeAtVectorIndex(main_vec, (obj *)tmp, 3);
+  storeAtVectorIndex(main_vec, (OBObjType *)tmp, 3);
 
   /* reduce reference count to 1, so only vector holds reference to obj */
-  release((obj *)tmp);
+  release((OBObjType *)tmp);
 
-  if(findObjInVector(main_vec, (obj *)singleton)){
+  if(findObjInVector(main_vec, (OBObjType *)singleton)){
     fprintf(stderr, "OBVector_test: vector did not replace element correctly, "
                     "or was not found\nTEST FAILED\n");
     exit(1);
   }
   
-  storeAtVectorIndex(main_vec, (obj *)singleton, 10);
+  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 10);
   if(vectorLength(main_vec) != 11){
     fprintf(stderr, "OBVector_test: store did not properly extend length "
                     "TEST FAILED\n");
@@ -128,7 +128,7 @@ int main(){
   }
 
   storeAtVectorIndex(main_vec, NULL, 6);
-  storeAtVectorIndex(main_vec, (obj *)singleton, 10);
+  storeAtVectorIndex(main_vec, (OBObjType *)singleton, 10);
 
   sortVector(main_vec, OB_GREATEST_TO_LEAST);
   if(vectorLength(main_vec) != 7){
@@ -149,14 +149,14 @@ int main(){
   
   copy_vec = copyVector(main_vec);
 
-  assert(compare((obj *)copy_vec, (obj *)main_vec) == OB_EQUAL_TO);
-  assert(hash((obj *)copy_vec) == hash((obj *)main_vec));
+  assert(compare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_EQUAL_TO);
+  assert(hash((OBObjType *)copy_vec) == hash((OBObjType *)main_vec));
 
-  release((obj *)singleton); /* release singleton once so it is only referenced
+  release((OBObjType *)singleton); /* release singleton once so it is only referenced
                                 by containing vectors */
 
   for(i=0; i<vectorLength(main_vec); i++){
-    if(referenceCount((obj *)(OBTest *)objAtVectorIndex(main_vec, i)) != 2){
+    if(referenceCount((OBObjType *)(OBTest *)objAtVectorIndex(main_vec, i)) != 2){
       fprintf(stderr, "OBVector_test: vector contents not retained on copy, "
                       "TEST FAILED\n");
       exit(1);
@@ -165,20 +165,20 @@ int main(){
   
   /* get obj at index and retain it so it isnt deallocated */
   tmp = (OBTest *)objAtVectorIndex(main_vec, 3);
-  retain((obj *)tmp);
+  retain((OBObjType *)tmp);
 
   storeAtVectorIndex(main_vec, NULL, 3);
 
-  assert(compare((obj *)copy_vec, (obj *)main_vec) == OB_NOT_EQUAL);
-  assert(hash((obj *)copy_vec) != hash((obj *)main_vec));
+  assert(compare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_NOT_EQUAL);
+  assert(hash((OBObjType *)copy_vec) != hash((OBObjType *)main_vec));
 
-  if(findObjInVector(main_vec, (obj *)tmp)){
+  if(findObjInVector(main_vec, (OBObjType *)tmp)){
     fprintf(stderr, "OBVector_test: Item was not removed properly from vector"
                     "index, TEST FAILED\n");
     exit(1);
   }
 
-  storeAtVectorIndex(main_vec, (obj *)tmp, 3);
+  storeAtVectorIndex(main_vec, (OBObjType *)tmp, 3);
   assert(vectorLength(main_vec) == 7);
   catVectors(main_vec, copy_vec);
   assert(vectorLength(main_vec) == 14);
@@ -192,17 +192,17 @@ int main(){
     }
   }
 
-  release((obj *)main_vec);
-  release((obj *)copy_vec);
+  release((OBObjType *)main_vec);
+  release((OBObjType *)copy_vec);
 
-  if(referenceCount((obj *)tmp) != 1){
+  if(referenceCount((OBObjType *)tmp) != 1){
     fprintf(stderr, "OBVector_test: releases of OBVector container did not "
                     "properly manage\ncontained OBTest reference count, TEST "
                     "FAILED\n");
     exit(1);
   }
 
-  release((obj *)tmp);
+  release((OBObjType *)tmp);
 
   printf("OBVector_test: TESTS PASSED\n");
   return 0;

--- a/src/tests/OBVector_test.c
+++ b/src/tests/OBVector_test.c
@@ -149,8 +149,8 @@ int main(){
   
   copy_vec = copyVector(main_vec);
 
-  assert(compare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_EQUAL_TO);
-  assert(hash((OBObjType *)copy_vec) == hash((OBObjType *)main_vec));
+  assert(OBCompare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_EQUAL_TO);
+  assert(OBHash((OBObjType *)copy_vec) == OBHash((OBObjType *)main_vec));
 
   OBRelease((OBObjType *)singleton); /* release singleton once so it is only referenced
                                 by containing vectors */
@@ -169,8 +169,8 @@ int main(){
 
   storeAtVectorIndex(main_vec, NULL, 3);
 
-  assert(compare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_NOT_EQUAL);
-  assert(hash((OBObjType *)copy_vec) != hash((OBObjType *)main_vec));
+  assert(OBCompare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_NOT_EQUAL);
+  assert(OBHash((OBObjType *)copy_vec) != OBHash((OBObjType *)main_vec));
 
   if(findObjInVector(main_vec, (OBObjType *)tmp)){
     fprintf(stderr, "OBVector_test: Item was not removed properly from vector"

--- a/src/tests/OBVector_test.c
+++ b/src/tests/OBVector_test.c
@@ -24,13 +24,13 @@ int main(){
     tests[i] = createTest(i);
     storeAtVectorIndex(main_vec, (OBObjType *)tests[i], i);
 
-    if(referenceCount((OBObjType *)tests[i]) != 2){
+    if(OBReferenceCount((OBObjType *)tests[i]) != 2){
       fprintf(stderr, "OBVector_test: vector did not properly retain element "
                       "TEST FAILED\n");
       exit(1);
     }
 
-    release((OBObjType *)tests[i]); /* vector should maintain only references */
+    OBRelease((OBObjType *)tests[i]); /* vector should maintain only references */
   }
 
   if(vectorLength(main_vec) != 6){
@@ -62,17 +62,17 @@ int main(){
     exit(1);
   }
 
-  if(referenceCount((OBObjType *)singleton) != 1){
+  if(OBReferenceCount((OBObjType *)singleton) != 1){
     fprintf(stderr, "OBVector_test: vector did not release element on removal "
                     "TEST FAILED\n");
     exit(1);
   }
 
   tmp = (OBTest *)objAtVectorIndex(main_vec, 3);
-  retain((OBObjType *)tmp);
+  OBRetain((OBObjType *)tmp);
 
   storeAtVectorIndex(main_vec, (OBObjType *)singleton, 3);
-  if(referenceCount((OBObjType *)tmp) != 1){
+  if(OBReferenceCount((OBObjType *)tmp) != 1){
     fprintf(stderr, "OBVector_test: vector did not release element on "
                     "replacement, TEST FAILED\n");
     exit(1);
@@ -89,7 +89,7 @@ int main(){
   storeAtVectorIndex(main_vec, (OBObjType *)tmp, 3);
 
   /* reduce reference count to 1, so only vector holds reference to obj */
-  release((OBObjType *)tmp);
+  OBRelease((OBObjType *)tmp);
 
   if(findObjInVector(main_vec, (OBObjType *)singleton)){
     fprintf(stderr, "OBVector_test: vector did not replace element correctly, "
@@ -152,11 +152,11 @@ int main(){
   assert(compare((OBObjType *)copy_vec, (OBObjType *)main_vec) == OB_EQUAL_TO);
   assert(hash((OBObjType *)copy_vec) == hash((OBObjType *)main_vec));
 
-  release((OBObjType *)singleton); /* release singleton once so it is only referenced
+  OBRelease((OBObjType *)singleton); /* release singleton once so it is only referenced
                                 by containing vectors */
 
   for(i=0; i<vectorLength(main_vec); i++){
-    if(referenceCount((OBObjType *)(OBTest *)objAtVectorIndex(main_vec, i)) != 2){
+    if(OBReferenceCount((OBObjType *)(OBTest *)objAtVectorIndex(main_vec, i)) != 2){
       fprintf(stderr, "OBVector_test: vector contents not retained on copy, "
                       "TEST FAILED\n");
       exit(1);
@@ -165,7 +165,7 @@ int main(){
   
   /* get obj at index and retain it so it isnt deallocated */
   tmp = (OBTest *)objAtVectorIndex(main_vec, 3);
-  retain((OBObjType *)tmp);
+  OBRetain((OBObjType *)tmp);
 
   storeAtVectorIndex(main_vec, NULL, 3);
 
@@ -192,17 +192,17 @@ int main(){
     }
   }
 
-  release((OBObjType *)main_vec);
-  release((OBObjType *)copy_vec);
+  OBRelease((OBObjType *)main_vec);
+  OBRelease((OBObjType *)copy_vec);
 
-  if(referenceCount((OBObjType *)tmp) != 1){
+  if(OBReferenceCount((OBObjType *)tmp) != 1){
     fprintf(stderr, "OBVector_test: releases of OBVector container did not "
                     "properly manage\ncontained OBTest reference count, TEST "
                     "FAILED\n");
     exit(1);
   }
 
-  release((OBObjType *)tmp);
+  OBRelease((OBObjType *)tmp);
 
   printf("OBVector_test: TESTS PASSED\n");
   return 0;


### PR DESCRIPTION
Hi,

I like the idea of Offbrand, but the API is kinda unusable for inconsistency, namespace pollution, and readability. So I renamed everything, after the fashion of Core Foundation. Made it consistent, readable, and tweaked a couple minor parts of the API. I also gave it an Xcode project, which I'm afraid isn't complete (haven't got the tests set up yet). 

I didn't make any drastic changes to the API (other than the wholesale replacement of obj \* with OBTypeRef), but I have a few thoughts about things you could do/add:
- retain and release - I really don't grok why release (now OBRelease) returns a OBTypeRef, but OBRetain returns void. If anything, it should be the opposite.
- Unicode support - what string library worth its salt doesn't have this in 2013? If you don't want it, don't have your own string datatype, just have your functions operate on C strings, maybe just wrapping string.h. 
- displayObj (OBDisplay) - get rid of it or at the very least add OBDescription so that objects can be put into format strings without having to access their internals. 
- Consider wrapping all public versions of the base functions in type-friendly versions; e.g. OBDequeHash(OBDeque *dq); It can just call down to the OBTypeRef version, or do it vice-versa. 

Anyway, hope this gives you some good ideas!
danhd123
